### PR TITLE
Implement trabajador activo helper

### DIFF
--- a/gestor-frontend/README.md
+++ b/gestor-frontend/README.md
@@ -10,3 +10,21 @@ Currently, two official plugins are available:
 ## Expanding the ESLint configuration
 
 If you are developing a production application, we recommend using TypeScript with type-aware lint rules enabled. Check out the [TS template](https://github.com/vitejs/vite/tree/main/packages/create-vite/template-react-ts) for information on how to integrate TypeScript and [`typescript-eslint`](https://typescript-eslint.io) in your project.
+
+## Manual checks for Trabajador status
+
+After updating the `Trabajador` component you can manually verify the active
+status logic:
+
+1. Run the frontend:
+
+   ```bash
+   cd gestor-frontend
+   npm install
+   npm run dev
+   ```
+
+2. En la aplicación, añade o edita un trabajador estableciendo una `fecha_baja`
+   futura (por ejemplo, dentro de un mes).
+3. Comprueba que el estado del trabajador aparece con la etiqueta verde
+   **Activo** a pesar de tener una fecha de baja en el futuro.

--- a/gestor-frontend/src/components/Trabajador.jsx
+++ b/gestor-frontend/src/components/Trabajador.jsx
@@ -11,6 +11,14 @@ import Header from '@/components/Header';
 import AddWorkerModal from '@/components/forms/AddWorkerModal';
 import EditWorkerModal from '@/components/forms/EditWorkerModal';
 
+// Determina si un trabajador está activo: la fecha de alta debe ser anterior o
+// igual a hoy y la fecha de baja debe ser nula o futura.
+export function isActivo(trabajador) {
+  const today = new Date();
+  const fechaAlta = new Date(trabajador.fecha_alta);
+  const fechaBaja = trabajador.fecha_baja ? new Date(trabajador.fecha_baja) : null;
+  return fechaAlta <= today && (!fechaBaja || fechaBaja >= today);
+}
 
 export default function Trabajador() {
   const [trabajadores, setTrabajadores] = useState([]);
@@ -178,9 +186,9 @@ const handleBaja = async (id) => {
                   </span>
                 )}
                 <span className={`ml-2 text-xs font-bold px-2 py-0.5 rounded-full ${
-                  t.fecha_baja ? 'bg-red-100 text-red-700' : 'bg-green-100 text-green-700'
+                  isActivo(t) ? 'bg-green-100 text-green-700' : 'bg-red-100 text-red-700'
                 }`}>
-                  {t.fecha_baja ? 'Inactivo' : 'Activo'}
+                  {isActivo(t) ? 'Activo' : 'Inactivo'}
                 </span>
               </div>
               {t.empresa && (


### PR DESCRIPTION
## Summary
- create `isActivo` helper for worker status
- use helper to show active or inactive label
- document how to manually check worker status logic

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68480fe277fc83219be841154431d909