### PR TITLE
Add setup documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,42 @@
+# ERP Personalizado
+
+Este proyecto es un ERP sencillo para gestionar trabajadores y programar sus horarios. Consta de un backend en Node.js y un frontend en React.
+
+## Configuración del backend
+
+1. Desde la carpeta `gestor-backend` instala las dependencias:
+   ```bash
+   npm install
+   ```
+2. Crea un archivo `.env` en `gestor-backend` definiendo las siguientes variables:
+   ```env
+   DB_HOST=localhost
+   DB_USER=tu_usuario
+   DB_PASSWORD=tu_contraseña
+   DB_NAME=gestor_horarios
+   PORT=3001 # opcional
+   CORS_ORIGIN=http://localhost:5173 # opcional
+   ```
+3. Inicia el servidor ejecutando:
+   ```bash
+   node index.js
+   ```
+
+## Configuración del frontend
+
+1. En la carpeta `gestor-frontend` instala las dependencias:
+   ```bash
+   npm install
+   ```
+2. Arranca el entorno de desarrollo con:
+   ```bash
+   npm run dev
+   ```
+
+## Base de datos
+
+El repositorio incluye una copia de respaldo en `db/backup_gestor_horarios.sql`. Crea una base de datos MySQL con el nombre que definas en `DB_NAME` e importa dicho archivo, por ejemplo:
+```bash
+mysql -u <usuario> -p < db/backup_gestor_horarios.sql
+```
+Esto generará las tablas necesarias para que la aplicación funcione.

--- a/gestor-frontend/README.md
+++ b/gestor-frontend/README.md
@@ -1,12 +1,3 @@
-# React + Vite
+# Gestor Frontend
 
-This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
-
-Currently, two official plugins are available:
-
-- [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react) uses [Babel](https://babeljs.io/) for Fast Refresh
-- [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react-swc) uses [SWC](https://swc.rs/) for Fast Refresh
-
-## Expanding the ESLint configuration
-
-If you are developing a production application, we recommend using TypeScript with type-aware lint rules enabled. Check out the [TS template](https://github.com/vitejs/vite/tree/main/packages/create-vite/template-react-ts) for information on how to integrate TypeScript and [`typescript-eslint`](https://typescript-eslint.io) in your project.
+Este proyecto contiene la interfaz realizada con React y Vite. Sigue las instrucciones de configuración del [README principal](../README.md) para ponerla en marcha.


### PR DESCRIPTION
## Summary
- document backend and frontend setup in root README
- replace placeholder frontend README with reference to root instructions

## Testing
- `npm test` in gestor-backend (fails: no test specified)
- `npm run lint` in gestor-frontend (fails: cannot find @eslint/js)

------
https://chatgpt.com/codex/tasks/task_e_6848100985388321a7b6fe462f815d68