### PR TITLE
Implement salary projections stats

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,3 +40,13 @@ El repositorio incluye una copia de respaldo en `db/backup_gestor_horarios.sql`.
 mysql -u <usuario> -p < db/backup_gestor_horarios.sql
 ```
 Esto generará las tablas necesarias para que la aplicación funcione.
+
+## API de estadísticas
+
+El backend expone un endpoint para obtener estadísticas y proyecciones basadas en los salarios de los trabajadores.
+
+```
+GET /api/trabajadores/estadisticas
+```
+
+La respuesta incluye el número total de trabajadores, cuántos están activos o inactivos y el coste salarial tanto mensual como anual.

--- a/gestor-backend/models/trabajador.model.js
+++ b/gestor-backend/models/trabajador.model.js
@@ -29,6 +29,3 @@ module.exports = (sequelize, DataTypes) => {
     freezeTableName: true // 👈 esto evita la pluralización (Trabajadors)
   });
 };
-//FECHA DE VENCIMIENTO DE CONTRATO
-//EPIS BOL SI/NO
-//IF SI == FECHA

--- a/gestor-backend/routes/trabajador.routes.js
+++ b/gestor-backend/routes/trabajador.routes.js
@@ -3,9 +3,11 @@ const router = express.Router();
 const trabajadorController = require('../controllers/trabajador.controller');
 
 router.get('/', trabajadorController.getAll);
+router.get('/estadisticas', trabajadorController.getStats);
 router.get('/:id', trabajadorController.getById);
 router.post('/', trabajadorController.create);
 router.put('/:id', trabajadorController.update);
 router.delete('/:id', trabajadorController.remove);
 
 module.exports = router;
+

--- a/gestor-frontend/src/App.jsx
+++ b/gestor-frontend/src/App.jsx
@@ -2,6 +2,7 @@ import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
 import Login from './components/Login';
 import Trabajador from './components/Trabajador';
 import ScheduleManager from './components/ScheduleManager';
+import Proyecciones from './components/Proyecciones';
 
 function App() {
   return (
@@ -9,10 +10,12 @@ function App() {
       <Routes>
         <Route path="/" element={<Login />} />
         <Route path="/trabajador" element={<Trabajador />} />
-        <Route path="/dashboard" element={<ScheduleManager />} /> 
+        <Route path="/dashboard" element={<ScheduleManager />} />
+        <Route path="/proyecciones" element={<Proyecciones />} />
       </Routes>
     </Router>
   );
 }
 
 export default App;
+

--- a/gestor-frontend/src/components/Proyecciones.jsx
+++ b/gestor-frontend/src/components/Proyecciones.jsx
@@ -1,0 +1,66 @@
+import { useEffect, useState } from 'react';
+import axios from 'axios';
+import Header from '@/components/Header';
+
+export default function Proyecciones() {
+  const [stats, setStats] = useState(null);
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    const fetchStats = async () => {
+      try {
+        const token = localStorage.getItem('token');
+        const res = await axios.get(`${import.meta.env.VITE_API_URL}/trabajadores/estadisticas`, {
+          headers: { Authorization: `Bearer ${token}` }
+        });
+        setStats(res.data);
+      } catch (err) {
+        console.error(err);
+        setError('No se pudieron cargar las estadísticas');
+      }
+    };
+
+    fetchStats();
+  }, []);
+
+  return (
+    <>
+      <Header />
+      <div className="min-h-screen bg-slate-100 p-6">
+        <h1 className="text-2xl font-bold mb-4">Proyecciones y Estadísticas</h1>
+        {error && <p className="text-red-600 mb-4">{error}</p>}
+        {stats ? (
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+            <div className="bg-white p-4 rounded shadow">
+              <p className="text-gray-500">Trabajadores totales</p>
+              <p className="text-2xl font-semibold">{stats.totalTrabajadores}</p>
+            </div>
+            <div className="bg-white p-4 rounded shadow">
+              <p className="text-gray-500">Activos</p>
+              <p className="text-2xl font-semibold">{stats.trabajadoresActivos}</p>
+            </div>
+            <div className="bg-white p-4 rounded shadow">
+              <p className="text-gray-500">Inactivos</p>
+              <p className="text-2xl font-semibold">{stats.trabajadoresInactivos}</p>
+            </div>
+            <div className="bg-white p-4 rounded shadow">
+              <p className="text-gray-500">Coste mensual bruto</p>
+              <p className="text-2xl font-semibold">€ {stats.costeMensualBruto}</p>
+            </div>
+            <div className="bg-white p-4 rounded shadow">
+              <p className="text-gray-500">Coste anual bruto</p>
+              <p className="text-2xl font-semibold">€ {stats.costeAnualBruto}</p>
+            </div>
+            <div className="bg-white p-4 rounded shadow">
+              <p className="text-gray-500">Salario bruto promedio</p>
+              <p className="text-2xl font-semibold">€ {stats.salarioBrutoPromedio.toFixed(2)}</p>
+            </div>
+          </div>
+        ) : (
+          <p>Cargando...</p>
+        )}
+      </div>
+    </>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add API route `/trabajadores/estadisticas` with controller logic
- document stats endpoint in README
- clean up stray text in `trabajador.model.js`
- include new React page `Proyecciones` to view stats
- register route and menu item in frontend

## Testing
- `npm test` within `gestor-backend` *(fails: Error: no test specified)*
- `npm test` within `gestor-frontend` *(fails: Missing script: "test")*
- `npm run lint` within `gestor-frontend` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684938d898048321a3c3bbd4f658c2ee