### PR TITLE
Improve authentication security

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,16 @@ mysql -u <usuario> -p < db/backup_gestor_horarios.sql
 ```
 Esto generará las tablas necesarias para que la aplicación funcione.
 
+## Seguridad
+
+Las contraseñas de la tabla `usuarios` deben almacenarse con hashing bcrypt. Cuando crees un usuario nuevo inserta la contraseña generada con:
+
+```bash
+node -e "console.log(require('bcrypt').hashSync('tu_clave', 10))"
+```
+
+Las rutas de trabajadores y horarios ahora requieren un token JWT válido en la cabecera `Authorization` con el formato `Bearer <token>`. Obtén el token mediante `/api/auth/login`.
+
 ## API de estadísticas
 
 El backend expone un endpoint para obtener estadísticas y proyecciones basadas en los salarios de los trabajadores.

--- a/gestor-backend/controllers/auth.controller.js
+++ b/gestor-backend/controllers/auth.controller.js
@@ -13,7 +13,8 @@ exports.login = async (req, res) => {
     if (rows.length === 0) return res.status(401).json({ error: 'Usuario no encontrado' });
 
     const usuario = rows[0];
-    if (contraseña !== usuario.contraseña) {
+    const coincide = await bcrypt.compare(contraseña, usuario.contraseña);
+    if (!coincide) {
       return res.status(401).json({ error: 'Contraseña incorrecta' });
     }
     

--- a/gestor-backend/middlewares/auth.js
+++ b/gestor-backend/middlewares/auth.js
@@ -1,0 +1,20 @@
+const jwt = require('jsonwebtoken');
+
+module.exports = (req, res, next) => {
+  const header = req.headers['authorization'];
+  const token = header && header.startsWith('Bearer ')
+    ? header.slice(7)
+    : req.headers['x-access-token'];
+
+  if (!token) {
+    return res.status(401).json({ error: 'Token requerido' });
+  }
+
+  try {
+    const decoded = jwt.verify(token, process.env.JWT_SECRET);
+    req.user = decoded;
+    next();
+  } catch (err) {
+    return res.status(401).json({ error: 'Token inválido' });
+  }
+};

--- a/gestor-backend/routes/horario.routes.js
+++ b/gestor-backend/routes/horario.routes.js
@@ -1,8 +1,9 @@
 const express = require('express');
 const router = express.Router();
+const auth = require('../middlewares/auth');
 const horarioController = require('../controllers/horario.controller');
 
-router.get('/:id', horarioController.getHorariosByTrabajador);
-router.post('/', horarioController.createOrUpdateHorarios);
+router.get('/:id', auth, horarioController.getHorariosByTrabajador);
+router.post('/', auth, horarioController.createOrUpdateHorarios);
 
 module.exports = router;

--- a/gestor-backend/routes/trabajador.routes.js
+++ b/gestor-backend/routes/trabajador.routes.js
@@ -1,13 +1,14 @@
 const express = require('express');
 const router = express.Router();
+const auth = require('../middlewares/auth');
 const trabajadorController = require('../controllers/trabajador.controller');
 
-router.get('/', trabajadorController.getAll);
-router.get('/estadisticas', trabajadorController.getStats);
-router.get('/:id', trabajadorController.getById);
-router.post('/', trabajadorController.create);
-router.put('/:id', trabajadorController.update);
-router.delete('/:id', trabajadorController.remove);
+router.get('/', auth, trabajadorController.getAll);
+router.get('/estadisticas', auth, trabajadorController.getStats);
+router.get('/:id', auth, trabajadorController.getById);
+router.post('/', auth, trabajadorController.create);
+router.put('/:id', auth, trabajadorController.update);
+router.delete('/:id', auth, trabajadorController.remove);
 
 module.exports = router;
 


### PR DESCRIPTION
## Summary
- hash passwords on login with bcrypt
- add JWT auth middleware
- protect horario and trabajador routes
- document hashed password creation and JWT use

## Testing
- `npm test` in `gestor-backend` *(fails: no test specified)*
- `npm test` in `gestor-frontend` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685519441fe0832b9e23bea27dadb6ff