### PR TITLE
Add ISO 27001 docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,3 +65,13 @@ GET /api/trabajadores/estadisticas
 ```
 
 La respuesta incluye el número total de trabajadores, cuántos están activos o inactivos y el coste salarial tanto mensual como anual.
+
+## Documentación ISO 27001
+
+En `docs/iso27001` se incluyen documentos básicos relacionados con la gestión de la seguridad de la información:
+
+- `security-policy.md`
+- `risk-assessment-methodology.md`
+- `asset-inventory.md`
+- `incident-response-procedure.md`
+- `access-control-policy.md`

--- a/docs/iso27001/access-control-policy.md
+++ b/docs/iso27001/access-control-policy.md
@@ -1,0 +1,3 @@
+# Access Control Policy
+
+This policy outlines the requirements for user account management, authentication mechanisms, and authorization controls. It aims to ensure that users only have access to the information and resources necessary for their roles.

--- a/docs/iso27001/asset-inventory.md
+++ b/docs/iso27001/asset-inventory.md
@@ -1,0 +1,3 @@
+# Asset Inventory
+
+This document lists the information assets that fall under the scope of the management system. Each asset is assigned an owner and categorized by sensitivity to help determine appropriate controls.

--- a/docs/iso27001/incident-response-procedure.md
+++ b/docs/iso27001/incident-response-procedure.md
@@ -1,0 +1,3 @@
+# Incident Response Procedure
+
+This procedure explains how the organization detects, reports and handles security incidents. It specifies the steps for containment, investigation and recovery, as well as communication requirements.

--- a/docs/iso27001/risk-assessment-methodology.md
+++ b/docs/iso27001/risk-assessment-methodology.md
@@ -1,0 +1,3 @@
+# Risk Assessment Methodology
+
+This file describes the method for identifying, evaluating and prioritizing risks to the organization. It includes guidance on determining likelihood and impact, as well as the criteria for risk treatment.

--- a/docs/iso27001/security-policy.md
+++ b/docs/iso27001/security-policy.md
@@ -1,0 +1,3 @@
+# Security Policy
+
+This document outlines the organization's commitment to protecting information assets. It defines high level security objectives, roles and responsibilities, and the overall approach to maintaining confidentiality, integrity and availability.


### PR DESCRIPTION
## Summary
- add an ISO 27001 docs section with security-related documents
- document the new folder in README

## Testing
- `npm test` in `gestor-backend` *(fails: no test specified)*
- `npm test` in `gestor-frontend` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68552504a39c832bbd3de93480ca7299