### PR TITLE
Fix CORS for local development

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Este proyecto es un ERP sencillo para gestionar trabajadores y programar sus hor
    DB_PASSWORD=tu_contraseña
    DB_NAME=gestor_horarios
    PORT=3001 # opcional
-   CORS_ORIGIN=http://localhost:5173 # opcional
+   CORS_ORIGIN=http://localhost:5173,http://localhost:3000 # opcional
    ```
 3. Inicia el servidor ejecutando:
    ```bash

--- a/gestor-backend/index.js
+++ b/gestor-backend/index.js
@@ -22,8 +22,13 @@ const PORT = process.env.PORT || 3001;
 // LOCAL
 //✅ CORS: permite llamadas desde frontend en local
 app.use(cors({
-  origin: process.env.CORS_ORIGIN?.split(',') || ['http://localhost:5173', 'https://lxherp.es'],
-  credentials: true
+  origin: process.env.CORS_ORIGIN?.split(',') || [
+    'http://localhost:5173',
+    'http://localhost:3000',
+    'https://lxherp.es'
+  ],
+  credentials: true,
+  optionsSuccessStatus: 200
 }));
 //PRODUCCION
 //✅ CORS: permite llamadas desde frontend en producción


### PR DESCRIPTION
## Summary
- include localhost:3000 in CORS defaults
- document multiple origins in setup instructions

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68553274fb48832b8598babfe1bd54ea