### PR TITLE
Add schedule export button and worker CSV template

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,3 +75,10 @@ En `docs/iso27001` se incluyen documentos básicos relacionados con la gestión 
 - `asset-inventory.md`
 - `incident-response-procedure.md`
 - `access-control-policy.md`
+
+## Plantillas de ejemplo
+
+En `docs/templates` encontrarás archivos CSV con el formato de las plantillas de horarios y de fichas de trabajador. Puedes modificarlos a tu gusto para generar tus propios modelos:
+
+- `plantilla_horarios.csv`
+- `plantilla_trabajador.csv`

--- a/docs/templates/plantilla_horarios.csv
+++ b/docs/templates/plantilla_horarios.csv
@@ -1,0 +1,2 @@
+trabajador_id,fecha,hora_inicio,hora_fin,festivo,proyecto_nombre
+1,2025-01-01,08:00,16:00,false,Proyecto Ejemplo

--- a/docs/templates/plantilla_trabajador.csv
+++ b/docs/templates/plantilla_trabajador.csv
@@ -1,0 +1,2 @@
+nombre,dni,correo_electronico,telefono,tipo_trabajador,grupo,categoria,iban,nss,fecha_alta,fecha_baja,horas_contratadas,salario_neto,salario_bruto,direccion,desplazamiento,fecha_desplazamiento,cliente,a1,fecha_limosa,condiciones,pais,epis,fecha_epis,empresa
+Juan Perez,12345678A,juan@example.com,600000000,Fijo,G1,Oficial 1,ES12345678901234567890,123456789012,2025-01-01,,40,1600,1800,"Calle Falsa 123",false,,Empresa X,false,,"Contrato indefinido",España,false,,MiEmpresa

--- a/gestor-frontend/src/components/ScheduleManager.jsx
+++ b/gestor-frontend/src/components/ScheduleManager.jsx
@@ -5,7 +5,8 @@ import { es } from 'date-fns/locale';
 import Header from '@/components/Header';
 import HorarioModal from '@/components/HorarioModal';
 import { HoursSummary } from '@/components/HorasResumen';
-import { ChevronLeft, ChevronRight, Settings, Folder } from 'lucide-react';
+import { ChevronLeft, ChevronRight, Settings, Folder, Download } from 'lucide-react';
+import { exportScheduleToExcel } from '@/utils/exportExcel';
 
 export default function ScheduleManager() {
   const [trabajadores, setTrabajadores] = useState([]);
@@ -66,6 +67,23 @@ export default function ScheduleManager() {
     });
   };
 
+  const handleDescargarPlantilla = async () => {
+    // Descarga el horario completo del trabajador seleccionado en formato Excel
+    try {
+      const token = localStorage.getItem('token');
+      const res = await axios.get(`${import.meta.env.VITE_API_URL}/horarios/${selectedTrabajadorId}`, {
+        headers: { Authorization: `Bearer ${token}` }
+      });
+      const trabajador = trabajadores.find(t => t.id === Number(selectedTrabajadorId));
+      if (trabajador) {
+        exportScheduleToExcel(trabajador, res.data);
+      }
+    } catch (err) {
+      console.error('Error al generar Excel:', err);
+      alert('No se pudo generar el archivo');
+    }
+  };
+
   useEffect(() => {
     const token = localStorage.getItem('token');
     axios.get(`${import.meta.env.VITE_API_URL}/trabajadores`, {
@@ -89,7 +107,7 @@ export default function ScheduleManager() {
   const formatHoursToHM = (total) => {
     const hours = Math.floor(total);
     const minutes = Math.round((total - hours) * 60);
-    return `${hours}:${minutes.toString().padStart(2, '0')}h`;
+    return `${hours.toString().padStart(2, '0')}:${minutes.toString().padStart(2, '0')}h`;
   };
 
   const groupedData = agruparHorarios(scheduleData);
@@ -189,6 +207,13 @@ export default function ScheduleManager() {
           >
             <Settings className="w-4 h-4" />
             Festivos Globales
+          </button>
+          <button
+            onClick={handleDescargarPlantilla}
+            className="inline-flex items-center gap-2 px-4 py-2 text-sm font-medium text-gray-700 bg-white border rounded shadow hover:bg-gray-50"
+          >
+            <Download className="w-4 h-4" />
+            Descargar Plantilla
           </button>
         </div>
 

--- a/gestor-frontend/src/components/Trabajador.jsx
+++ b/gestor-frontend/src/components/Trabajador.jsx
@@ -10,7 +10,7 @@ import { motion, AnimatePresence } from 'framer-motion';
 import Header from '@/components/Header';
 import AddWorkerModal from '@/components/forms/AddWorkerModal';
 import EditWorkerModal from '@/components/forms/EditWorkerModal';
-import { exportScheduleToExcel } from '@/utils/exportExcel';
+import { exportWorkerToCsv } from '@/utils/exportWorkerCsv';
 
 // Determina si un trabajador está activo: la fecha de alta debe ser anterior o
 // igual a hoy y la fecha de baja debe ser nula o futura.
@@ -133,15 +133,12 @@ const handleBaja = async (id) => {
     setShowEditModal(true);
   };
 
-  const handleDescargarPlantilla = async (trabajador) => {
-    const token = localStorage.getItem('token');
+  const handleDescargarPlantilla = (trabajador) => {
+    // Exporta los datos del trabajador como CSV para poder usarlos como plantilla
     try {
-      const res = await axios.get(`${import.meta.env.VITE_API_URL}/horarios/${trabajador.id}`, {
-        headers: { Authorization: `Bearer ${token}` }
-      });
-      exportScheduleToExcel(trabajador, res.data);
+      exportWorkerToCsv(trabajador);
     } catch (err) {
-      console.error('Error al generar Excel:', err);
+      console.error('Error al generar CSV:', err);
       alert('No se pudo generar el archivo');
     }
   };

--- a/gestor-frontend/src/utils/exportWorkerCsv.js
+++ b/gestor-frontend/src/utils/exportWorkerCsv.js
@@ -1,0 +1,16 @@
+import { exportObjectToCSV } from './exportCsv.js';
+
+export function exportWorkerToCsv(trabajador) {
+  const fields = [
+    'nombre', 'dni', 'correo_electronico', 'telefono', 'tipo_trabajador',
+    'grupo', 'categoria', 'iban', 'nss', 'fecha_alta', 'fecha_baja',
+    'horas_contratadas', 'salario_neto', 'salario_bruto', 'direccion',
+    'desplazamiento', 'fecha_desplazamiento', 'cliente', 'a1', 'fecha_limosa',
+    'condiciones', 'pais', 'epis', 'fecha_epis', 'empresa'
+  ];
+  const obj = {};
+  fields.forEach(f => {
+    obj[f] = trabajador[f] ?? '';
+  });
+  exportObjectToCSV(obj, `trabajador_${trabajador.nombre}.csv`);
+}

--- a/gestor-frontend/src/utils/utils.js
+++ b/gestor-frontend/src/utils/utils.js
@@ -19,5 +19,5 @@ export function formatHours(value) {
 export const formatHoursToHM = (total) => {
   const hours = Math.floor(total);
   const minutes = Math.round((total - hours) * 60);
-  return `${hours}:${minutes.toString().padStart(2, '0')}h`;
+  return `${hours.toString().padStart(2, '0')}:${minutes.toString().padStart(2, '0')}h`;
 };


### PR DESCRIPTION
## Summary
- export worker info to CSV
- move schedule export to horario page and format hours as HH:MM
- document new templates and include example CSV files

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685bce30a944832ba05dcf84ed558336