### PR TITLE
Add weekend and holiday styling to exported schedule

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,3 +87,4 @@ En `docs/templates` encontrarás archivos CSV con el formato de las plantillas d
 `hora_entrada_1`, `hora_salida_1`, `hora_entrada_2` y `hora_salida_2`.
 Si el segundo intervalo no se usa, se deben rellenar sus columnas con `00:00`.
 Al exportar los horarios a Excel también se mostrarán estas cuatro columnas para reflejar todas las entradas y salidas registradas.
+Las horas totales y extras se muestran en formato `HH:mm`. Las filas de fines de semana se colorean de gris y las de festivos de morado para diferenciarlas en la plantilla descargable.

--- a/gestor-frontend/package.json
+++ b/gestor-frontend/package.json
@@ -35,6 +35,7 @@
     "react-router-dom": "^6.16.0",
     "recharts": "^2.15.3",
     "xlsx": "^0.18.5",
+    "xlsx-js-style": "^1.0.0",
     "tailwind-merge": "^1.14.0",
     "tailwind-variants": "^1.0.0",
     "tailwindcss-animate": "^1.0.7",


### PR DESCRIPTION
## Summary
- tweak README to document new formatting
- add `xlsx-js-style` dependency for styling
- support weekend and holiday row colours in exported Excel template
- display hour totals in `HH:mm` format and leave gaps when no hours

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685bf9bec838832b9335d5ddf595a5e4