### PR TITLE
Hide zero hours in export

### DIFF
--- a/gestor-frontend/src/utils/exportExcel.js
+++ b/gestor-frontend/src/utils/exportExcel.js
@@ -10,6 +10,11 @@ function calcDuration(start, end) {
 }
 
 function toHM(num) {
+  // If the value is zero or undefined return an empty string so that
+  // the exported template does not display "00:00" for missing hours
+  if (num === 0 || num === undefined || num === null) {
+    return '';
+  }
   const hours = Math.floor(num);
   const minutes = Math.round((num - hours) * 60);
   return `${hours.toString().padStart(2, '0')}:${minutes.toString().padStart(2, '0')}`;


### PR DESCRIPTION
## Summary
- avoid displaying 00:00 for missing hours in the Excel schedule export

## Testing
- `npm --prefix gestor-frontend run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685c02b41c40832bbe9ed4b5297083de