### PR TITLE
Improve Excel export with logo and formatting

### DIFF
--- a/gestor-frontend/package.json
+++ b/gestor-frontend/package.json
@@ -37,6 +37,7 @@
     "recharts": "^2.15.3",
     "xlsx": "^0.18.5",
     "xlsx-js-style": "^1.0.0",
+    "exceljs": "^4.3.0",
     "tailwind-merge": "^1.14.0",
     "tailwind-variants": "^1.0.0",
     "tailwindcss-animate": "^1.0.7",


### PR DESCRIPTION
## Summary
- switch exportExcel to use `exceljs`
- add company logo, page setup and new info rows
- apply Century Gothic font and border tweaks
- add `exceljs` dependency

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` in frontend *(fails: missing script)*
- `npm test` in backend *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_685c0845e080832bbfe665ed3c7ed517