### PR TITLE
Add nocturnal hours to schedule template

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,6 @@ En `docs/templates` encontrarás archivos con el formato de las plantillas de ho
 `plantilla_horarios.csv` incluye columnas para hasta dos intervalos de trabajo:
 `entrada_1`, `salida_1`, `entrada_2` y `salida_2`.
 Si el segundo intervalo no se usa, se deben rellenar sus columnas con `00:00`.
-Al exportar los horarios a Excel se muestran estas cuatro columnas junto con las horas normales, extras y festivas, y una fila de totales al final.
+Al exportar los horarios a Excel se muestran estas cuatro columnas junto con las horas normales, extras, nocturnas y festivas, y una fila de totales al final.
 Las horas se muestran en formato `HH:mm`. Las filas de fines de semana se colorean de gris y las de festivos de morado para diferenciarlas en la plantilla descargable.
-Las columnas del Excel se generan con una anchura moderada y con bordes en todas las celdas. La primera fila queda vacía para que puedas colocar el logotipo de la empresa. Toda la lógica de exportación se encuentra en `gestor-frontend/src/utils/exportExcel.js`.
+Las columnas del Excel se generan con una anchura moderada y con bordes en todas las celdas. El área superior ahora incluye un recuadro con la información del trabajador y un recuadro separado para el logotipo. Toda la lógica de exportación se encuentra en `gestor-frontend/src/utils/exportExcel.js`.


### PR DESCRIPTION
## Summary
- include nocturnal hours when exporting schedules
- enlarge worker name in Excel template
- draw bordered boxes for logo and worker info
- update README about new column and template layout

## Testing
- `npm --prefix gestor-frontend run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685d02733858832bbd54498dd8c72b80