### PR TITLE
Fix midnight intervals

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,3 +92,4 @@ Si el segundo intervalo no se usa, se deben rellenar sus columnas con `00:00`.
 Al exportar los horarios a Excel se muestran estas cuatro columnas junto con las horas normales, extras, nocturnas y festivas, y una fila de totales al final.
 Las horas se muestran en formato `HH:mm`. Las filas de fines de semana se colorean de gris y las de festivos de morado para diferenciarlas en la plantilla descargable.
 Las columnas del Excel se generan con una anchura moderada y con bordes en todas las celdas. El área superior ahora incluye un recuadro con la información del trabajador y un recuadro separado para el logotipo. Toda la lógica de exportación se encuentra en `gestor-frontend/src/utils/exportExcel.js`.
+Los cálculos de horas contemplan ahora intervalos que cruzan la medianoche, de forma que un rango como `22:00` a `04:00` se suma correctamente al total y a las horas nocturnas.

--- a/gestor-frontend/src/components/HorasResumen.jsx
+++ b/gestor-frontend/src/components/HorasResumen.jsx
@@ -17,8 +17,11 @@ function calcularTipoHoras(intervals, dateKey, isFestivo) {
     if (!hora_inicio || !hora_fin) return;
     const [h1, m1] = hora_inicio.split(':').map(Number);
     const [h2, m2] = hora_fin.split(':').map(Number);
-    const start = h1 * 60 + m1;
-    const end = h2 * 60 + m2;
+    let start = h1 * 60 + m1;
+    let end = h2 * 60 + m2;
+    if (end <= start) {
+      end += 24 * 60; // Interval crosses midnight
+    }
     let total = (end - start) / 60;
 
     const dia = getDay(parseISO(dateKey));

--- a/gestor-frontend/src/utils/exportExcel.js
+++ b/gestor-frontend/src/utils/exportExcel.js
@@ -5,7 +5,12 @@ import { es } from 'date-fns/locale';
 function calcDuration(start, end) {
   const [h1, m1] = start.split(':').map(Number);
   const [h2, m2] = end.split(':').map(Number);
-  return ((h2 * 60 + m2) - (h1 * 60 + m1)) / 60;
+  let s = h1 * 60 + m1;
+  let e = h2 * 60 + m2;
+  if (e <= s) {
+    e += 24 * 60; // crosses midnight
+  }
+  return (e - s) / 60;
 }
 
 function classifyIntervals(intervals, date, isHoliday) {
@@ -27,6 +32,9 @@ function classifyIntervals(intervals, date, isHoliday) {
     const [h2, m2] = end.split(':').map(Number);
     let startMin = h1 * 60 + m1;
     let endMin = h2 * 60 + m2;
+    if (endMin <= startMin) {
+      endMin += 24 * 60; // crosses midnight
+    }
     if (startMin < 360) {
       const noctEnd = Math.min(endMin, 360);
       nocturnas += (noctEnd - startMin) / 60;

--- a/gestor-frontend/src/utils/utils.js
+++ b/gestor-frontend/src/utils/utils.js
@@ -5,7 +5,12 @@ export function calculateTotalHoursFromIntervals(intervals) {
     if (hora_inicio && hora_fin) {
       const [h1, m1] = hora_inicio.split(':').map(Number);
       const [h2, m2] = hora_fin.split(':').map(Number);
-      return sum + ((h2 * 60 + m2) - (h1 * 60 + m1)) / 60;
+      let start = h1 * 60 + m1;
+      let end = h2 * 60 + m2;
+      if (end <= start) {
+        end += 24 * 60; // Crosses midnight
+      }
+      return sum + (end - start) / 60;
     }
     return sum;
   }, 0);


### PR DESCRIPTION
## Summary
- handle intervals that cross midnight in utils and summaries
- update schedule Excel export classification for midnight spans
- document midnight interval handling in README

## Testing
- `npm --prefix gestor-frontend run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685e5fbaa880832b84097b7ccb810cf9