### PR TITLE
Add worker autocomplete

### DIFF
--- a/gestor-frontend/src/components/ScheduleManager.jsx
+++ b/gestor-frontend/src/components/ScheduleManager.jsx
@@ -4,6 +4,7 @@ import { format, startOfMonth, getDaysInMonth, getDay } from 'date-fns';
 import { es } from 'date-fns/locale';
 import Header from '@/components/Header';
 import HorarioModal from '@/components/HorarioModal';
+import WorkerAutocomplete from '@/components/WorkerAutocomplete';
 import { HoursSummary } from '@/components/HorasResumen';
 import { ChevronLeft, ChevronRight, Settings, Folder, Download } from 'lucide-react';
 import { exportScheduleToExcel } from '@/utils/exportExcel';
@@ -191,15 +192,11 @@ export default function ScheduleManager() {
         <div className="max-w-5xl mx-auto mb-4 flex flex-col sm:flex-row justify-between items-center gap-4">
           <div className="w-full sm:w-auto">
             <label className="block text-sm font-medium text-gray-700 mb-1">Seleccionar Trabajador:</label>
-            <select
-              className="w-full sm:w-64 p-3 text-base border border-gray-300 rounded bg-white shadow-sm text-black"
-              value={selectedTrabajadorId}
-              onChange={(e) => setSelectedTrabajadorId(e.target.value)}
-            >
-              {trabajadores.map((t) => (
-                <option key={t.id} value={t.id}>{t.nombre}</option>
-              ))}
-            </select>
+            <WorkerAutocomplete
+              workers={trabajadores}
+              selectedId={selectedTrabajadorId}
+              onChange={setSelectedTrabajadorId}
+            />
           </div>
           <button
             onClick={() => alert('Aquí iría el modal de festivos')}

--- a/gestor-frontend/src/components/WorkerAutocomplete.jsx
+++ b/gestor-frontend/src/components/WorkerAutocomplete.jsx
@@ -1,0 +1,54 @@
+import React, { useState, useEffect } from 'react';
+
+export default function WorkerAutocomplete({ workers = [], selectedId, onChange }) {
+  const [query, setQuery] = useState('');
+  const [open, setOpen] = useState(false);
+
+  useEffect(() => {
+    const selected = workers.find(w => w.id === Number(selectedId));
+    if (selected) {
+      setQuery(selected.nombre);
+    }
+  }, [selectedId, workers]);
+
+  const filtered = workers.filter(w => w.nombre.toLowerCase().includes(query.toLowerCase()));
+
+  const handleSelect = (worker) => {
+    onChange(worker.id);
+    setQuery(worker.nombre);
+    setOpen(false);
+  };
+
+  return (
+    <div className="relative w-full sm:w-64">
+      <input
+        type="text"
+        className="w-full p-3 text-base border border-gray-300 rounded bg-white shadow-sm text-black"
+        placeholder="Buscar trabajador..."
+        value={query}
+        onChange={(e) => {
+          setQuery(e.target.value);
+          setOpen(true);
+        }}
+        onFocus={() => setOpen(true)}
+        onBlur={() => setTimeout(() => setOpen(false), 100)}
+      />
+      {open && (
+        <ul className="absolute z-10 w-full bg-white border border-gray-300 rounded shadow mt-1 max-h-60 overflow-y-auto">
+          {filtered.map((w) => (
+            <li
+              key={w.id}
+              className="px-3 py-2 hover:bg-gray-100 cursor-pointer"
+              onMouseDown={() => handleSelect(w)}
+            >
+              {w.nombre}
+            </li>
+          ))}
+          {filtered.length === 0 && (
+            <li className="px-3 py-2 text-gray-500">Sin resultados</li>
+          )}
+        </ul>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add WorkerAutocomplete component
- use WorkerAutocomplete in ScheduleManager to let users type and search workers

## Testing
- `npm run lint` *(fails: eslint not found)*

------
https://chatgpt.com/codex/tasks/task_e_6887248ab114832bac4f31d846200b0e