### PR TITLE
Add vacation day handling

### DIFF
--- a/gestor-backend/controllers/horario.controller.js
+++ b/gestor-backend/controllers/horario.controller.js
@@ -14,7 +14,7 @@ exports.getHorariosByTrabajador = async (req, res) => {
 };
 exports.createOrUpdateHorarios = async (req, res) => {
   try {
-    const { trabajador_id, fecha, horarios, festivo, proyecto_nombre } = req.body;
+    const { trabajador_id, fecha, horarios, festivo, vacaciones, proyecto_nombre } = req.body;
 
     // Borrar los horarios anteriores del mismo día
     await Horario.destroy({
@@ -31,6 +31,7 @@ exports.createOrUpdateHorarios = async (req, res) => {
           hora_inicio: h.hora_inicio,
           hora_fin: h.hora_fin,
           festivo: festivo || false,
+          vacaciones: vacaciones || false,
           proyecto_nombre: proyecto_nombre || null
         });
       });
@@ -42,6 +43,18 @@ exports.createOrUpdateHorarios = async (req, res) => {
         hora_inicio: '00:00:00',
         hora_fin: '00:00:00',
         festivo: true,
+        vacaciones: vacaciones || false,
+        proyecto_nombre: proyecto_nombre || null
+      });
+    } else if (vacaciones) {
+      // Registrar el día como vacaciones sin horas
+      nuevos.push({
+        trabajador_id,
+        fecha,
+        hora_inicio: '00:00:00',
+        hora_fin: '00:00:00',
+        festivo: false,
+        vacaciones: true,
         proyecto_nombre: proyecto_nombre || null
       });
     }

--- a/gestor-backend/models/horario.model.js
+++ b/gestor-backend/models/horario.model.js
@@ -26,6 +26,10 @@ module.exports = (sequelize, DataTypes) => {
       type: DataTypes.BOOLEAN,
       defaultValue: false,
     },
+    vacaciones: {
+      type: DataTypes.BOOLEAN,
+      defaultValue: false,
+    },
     proyecto_nombre: {
       type: DataTypes.STRING,
       allowNull: true,

--- a/gestor-frontend/src/components/HorarioModal.jsx
+++ b/gestor-frontend/src/components/HorarioModal.jsx
@@ -3,15 +3,17 @@ import { Dialog } from '@headlessui/react';
 import { format, isValid } from 'date-fns';
 import { v4 as uuidv4 } from 'uuid';
 
-export default function HorarioModal({ isOpen, onClose, fecha, onSave, initialData = [], initialFestivo = false }) {
+export default function HorarioModal({ isOpen, onClose, fecha, onSave, initialData = [], initialFestivo = false, initialVacaciones = false }) {
   const [intervals, setIntervals] = useState([]);
   const [isHoliday, setIsHoliday] = useState(false);
+  const [isVacation, setIsVacation] = useState(false);
   const [proyectoNombre, setProyectoNombre] = useState(null);
   const [editarProyecto, setEditarProyecto] = useState(false);
   
   useEffect(() => {
-  setIntervals(initialData.map(item => ({ ...item, id: uuidv4() })));
-  setIsHoliday(initialFestivo);
+    setIntervals(initialData.map(item => ({ ...item, id: uuidv4() })));
+    setIsHoliday(initialFestivo);
+    setIsVacation(initialVacaciones);
 
   // ✅ Detectar el proyecto si todos los intervalos tienen el mismo nombre
   if (initialData.length > 0 && initialData.every(i => i.proyecto_nombre === initialData[0].proyecto_nombre)) {
@@ -21,7 +23,7 @@ export default function HorarioModal({ isOpen, onClose, fecha, onSave, initialDa
     setProyectoNombre('');
     setEditarProyecto(false);
   }
-}, [initialData, initialFestivo, fecha]);
+  }, [initialData, initialFestivo, initialVacaciones, fecha]);
 
 
   const handleAddInterval = () => {
@@ -41,6 +43,7 @@ export default function HorarioModal({ isOpen, onClose, fecha, onSave, initialDa
       fecha,
       intervals,
       festivo: isHoliday,
+      vacaciones: isVacation,
       proyecto_nombre: proyectoNombre?.trim() || null
     });
     onClose();
@@ -49,6 +52,7 @@ export default function HorarioModal({ isOpen, onClose, fecha, onSave, initialDa
   const handleClear = () => {
     setIntervals([]);
     setIsHoliday(false);
+    setIsVacation(false);
     setProyectoNombre(null);
     setEditarProyecto(false);
   };
@@ -71,7 +75,11 @@ export default function HorarioModal({ isOpen, onClose, fecha, onSave, initialDa
     <Dialog open={isOpen} onClose={onClose} className="fixed z-50 inset-0 overflow-y-auto">
       <div className="flex items-center justify-center min-h-screen p-4 bg-black/40">
           <Dialog.Panel className={`w-full max-w-md rounded-lg shadow-lg p-6 transition-colors duration-300 ${
-            isHoliday ? 'bg-purple-50 text-purple-900' : 'bg-white text-black'
+            isVacation
+              ? 'bg-green-50 text-green-900'
+              : isHoliday
+              ? 'bg-purple-50 text-purple-900'
+              : 'bg-white text-black'
           }`}>
           <Dialog.Title className="text-lg font-bold mb-2">Gestionar Horas</Dialog.Title>
           <p className="text-sm mb-4">
@@ -109,6 +117,15 @@ export default function HorarioModal({ isOpen, onClose, fecha, onSave, initialDa
                 onChange={(e) => setIsHoliday(e.target.checked)}
               />
               Marcar como Festivo (para este trabajador)
+            </label>
+
+            <label className="flex items-center gap-2 mt-3">
+              <input
+                type="checkbox"
+                checked={isVacation}
+                onChange={(e) => setIsVacation(e.target.checked)}
+              />
+              Marcar como Vacaciones (para este trabajador)
             </label>
 
             <label className="flex flex-col gap-2 mt-3">

--- a/gestor-frontend/src/components/HorasResumen.jsx
+++ b/gestor-frontend/src/components/HorasResumen.jsx
@@ -6,7 +6,7 @@ import { getYear, getMonth, getDay, parseISO } from 'date-fns';
 import { calculateTotalHoursFromIntervals, formatHoursToHM } from '../utils/utils';
 
 
-function calcularTipoHoras(intervals, dateKey, isFestivo) {
+function calcularTipoHoras(intervals, dateKey, isFestivo, isVacaciones) {
   let totalDiario = 0;
   let normales = 0,
     extras = 0,
@@ -25,6 +25,11 @@ function calcularTipoHoras(intervals, dateKey, isFestivo) {
     let total = (end - start) / 60;
 
     const dia = getDay(parseISO(dateKey));
+
+    if (isVacaciones) {
+      extras += total;
+      return;
+    }
 
     if (dia === 0 || dia === 6 || isFestivo) {
       festivas += total;
@@ -66,7 +71,12 @@ export function HoursSummary({ currentDate, scheduleData }) {
   Object.entries(scheduleData).forEach(([dateKey, entry]) => {
     const d = parseISO(dateKey);
     if (getYear(d) === year && getMonth(d) === month) {
-      const tipo = calcularTipoHoras(entry.intervals || [], dateKey, entry.isHoliday);
+      const tipo = calcularTipoHoras(
+        entry.intervals || [],
+        dateKey,
+        entry.isHoliday,
+        entry.isVacation
+      );
       resumen.normales += tipo.normales;
       resumen.extras += tipo.extras;
       resumen.nocturnas += tipo.nocturnas;


### PR DESCRIPTION
## Summary
- add `vacaciones` field to horario model
- support vacaciones in horario controller
- show/edit vacaciones in modal and calendar
- export vacation info to Excel
- count vacation hours as extras in summaries

## Testing
- `npm test` within `gestor-backend` *(fails: Error: no test specified)*
- `npm test` within `gestor-frontend` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68872798fbdc832baa84415d1dcdd4ce