### PR TITLE
Fix 00:00 interval calculations

### DIFF
--- a/gestor-frontend/src/components/HorasResumen.jsx
+++ b/gestor-frontend/src/components/HorasResumen.jsx
@@ -19,6 +19,7 @@ function calcularTipoHoras(intervals, dateKey, isFestivo, isVacaciones) {
     const [h2, m2] = hora_fin.split(':').map(Number);
     let start = h1 * 60 + m1;
     let end = h2 * 60 + m2;
+    if (start === end) return; // zero length interval
     if (end <= start) {
       end += 24 * 60; // Interval crosses midnight
     }

--- a/gestor-frontend/src/utils/exportExcel.js
+++ b/gestor-frontend/src/utils/exportExcel.js
@@ -1,17 +1,8 @@
 import ExcelJS from 'exceljs';
 import { format, parseISO, getDay } from 'date-fns';
 import { es } from 'date-fns/locale';
+import { calcDuration } from './utils';
 
-function calcDuration(start, end) {
-  const [h1, m1] = start.split(':').map(Number);
-  const [h2, m2] = end.split(':').map(Number);
-  let s = h1 * 60 + m1;
-  let e = h2 * 60 + m2;
-  if (e <= s) {
-    e += 24 * 60; // crosses midnight
-  }
-  return (e - s) / 60;
-}
 
 function classifyIntervals(intervals, date, isHoliday, isVacation) {
   const day = getDay(parseISO(date));
@@ -39,6 +30,9 @@ function classifyIntervals(intervals, date, isHoliday, isVacation) {
     const [h2, m2] = end.split(':').map(Number);
     let startMin = h1 * 60 + m1;
     let endMin = h2 * 60 + m2;
+    if (startMin === endMin) {
+      return; // zero length interval
+    }
     if (endMin <= startMin) {
       endMin += 24 * 60; // crosses midnight
     }

--- a/gestor-frontend/src/utils/utils.js
+++ b/gestor-frontend/src/utils/utils.js
@@ -1,16 +1,21 @@
 // src/utils/utils.js
 
+export function calcDuration(start, end) {
+  const [h1, m1] = start.split(':').map(Number);
+  const [h2, m2] = end.split(':').map(Number);
+  let s = h1 * 60 + m1;
+  let e = h2 * 60 + m2;
+  if (s === e) return 0; // treat equal times as zero duration
+  if (e <= s) {
+    e += 24 * 60; // crosses midnight
+  }
+  return (e - s) / 60;
+}
+
 export function calculateTotalHoursFromIntervals(intervals) {
   return intervals.reduce((sum, { hora_inicio, hora_fin }) => {
     if (hora_inicio && hora_fin) {
-      const [h1, m1] = hora_inicio.split(':').map(Number);
-      const [h2, m2] = hora_fin.split(':').map(Number);
-      let start = h1 * 60 + m1;
-      let end = h2 * 60 + m2;
-      if (end <= start) {
-        end += 24 * 60; // Crosses midnight
-      }
-      return sum + (end - start) / 60;
+      return sum + calcDuration(hora_inicio, hora_fin);
     }
     return sum;
   }, 0);


### PR DESCRIPTION
## Summary
- treat intervals with equal start and end time as zero duration
- reuse a new `calcDuration` helper across utils and Excel export
- skip zero-length intervals when summarizing hours

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm install` *(fails: 403 Forbidden - registry.npmjs.org)*

------
https://chatgpt.com/codex/tasks/task_e_68872a5c3dcc832bb798157c51f526c0