### PR TITLE
Formato europeo para salarios

### DIFF
--- a/gestor-frontend/src/components/Proyecciones.jsx
+++ b/gestor-frontend/src/components/Proyecciones.jsx
@@ -4,6 +4,7 @@ import Header from '@/components/Header';
 import {
   BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer
 } from 'recharts';
+import { formatCurrency } from '@/utils/utils';
 
 export default function Proyecciones() {
   const [stats, setStats] = useState(null);
@@ -55,9 +56,9 @@ export default function Proyecciones() {
               <StatCard title="Trabajadores totales" value={stats.totalTrabajadores} />
               <StatCard title="Activos" value={stats.trabajadoresActivos} />
               <StatCard title="Inactivos" value={stats.trabajadoresInactivos} />
-              <StatCard title="Coste mensual bruto" value={`€ ${stats.costeMensualBruto}`} />
-              <StatCard title="Coste anual bruto" value={`€ ${stats.costeAnualBruto}`} />
-              <StatCard title="Salario bruto promedio" value={`€ ${stats.salarioBrutoPromedio.toFixed(2)}`} />
+              <StatCard title="Coste mensual bruto" value={`€ ${formatCurrency(stats.costeMensualBruto)}`} />
+              <StatCard title="Coste anual bruto" value={`€ ${formatCurrency(stats.costeAnualBruto)}`} />
+              <StatCard title="Salario bruto promedio" value={`€ ${formatCurrency(stats.salarioBrutoPromedio)}`} />
             </div>
 
             <div className="max-w-5xl mx-auto bg-white p-6 rounded-xl shadow-xl">

--- a/gestor-frontend/src/components/Trabajador.jsx
+++ b/gestor-frontend/src/components/Trabajador.jsx
@@ -11,6 +11,7 @@ import Header from '@/components/Header';
 import AddWorkerModal from '@/components/forms/AddWorkerModal';
 import EditWorkerModal from '@/components/forms/EditWorkerModal';
 import { exportWorkerToExcel } from '@/utils/exportWorkerExcel';
+import { formatCurrency } from '@/utils/utils';
 
 // Determina si un trabajador está activo: la fecha de alta debe ser anterior o
 // igual a hoy y la fecha de baja debe ser nula o futura.
@@ -238,8 +239,8 @@ const handleBaja = async (id) => {
                     <p><Calendar className="inline w-4 h-4 mr-1 text-blue-500" /> Alta: {formatDate(t.fecha_alta)}</p>
                     {t.fecha_baja && (<p><Calendar className="inline w-4 h-4 mr-1 text-red-500" /> Baja: {formatDate(t.fecha_baja)}</p>)}
                     <p><Clock className="inline w-4 h-4 mr-1 text-gray-700" /> Horas: {t.horas_contratadas}</p>
-                    <p><Euro className="inline w-4 h-4 mr-1 text-emerald-500" /> Salario Neto: {t.salario_neto} €</p>
-                    <p><Euro className="inline w-4 h-4 mr-1 text-emerald-300" /> Salario Bruto: {t.salario_bruto} €</p>
+                    <p><Euro className="inline w-4 h-4 mr-1 text-emerald-500" /> Salario Neto: {formatCurrency(t.salario_neto)} €</p>
+                    <p><Euro className="inline w-4 h-4 mr-1 text-emerald-300" /> Salario Bruto: {formatCurrency(t.salario_bruto)} €</p>
                     <p><User className="inline w-4 h-4 mr-1 text-red-500" /> Cliente: {t.cliente}</p>
                     <p>A1: {t.a1 ? 'Sí' : 'No'}</p>
                     <p>Fecha A1: {t.fecha_limosa ? formatDate(t.fecha_limosa) : 'N/A'}</p>

--- a/gestor-frontend/src/components/forms/AddWorkerModal.jsx
+++ b/gestor-frontend/src/components/forms/AddWorkerModal.jsx
@@ -1,6 +1,7 @@
 // src/components/forms/AddWorkerModal.jsx
 import React, { useState } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
+import { parseCurrency } from '@/utils/utils';
 
 export default function AddWorkerModal({ open, onClose, onWorkerAdded }) {
   const [form, setForm] = useState({
@@ -35,7 +36,12 @@ export default function AddWorkerModal({ open, onClose, onWorkerAdded }) {
 
   const handleChange = (e) => {
     const { name, value, type, checked } = e.target;
-    setForm((prev) => ({ ...prev, [name]: type === 'checkbox' ? checked : value }));
+    if (["salario_neto", "salario_bruto"].includes(name)) {
+      const formatted = value.replace(/[^0-9.,]/g, "");
+      setForm((prev) => ({ ...prev, [name]: formatted }));
+    } else {
+      setForm((prev) => ({ ...prev, [name]: type === "checkbox" ? checked : value }));
+    }
     setFormErrors((prev) => ({ ...prev, [name]: undefined })); // limpia error del campo al modificar
   };
 
@@ -68,6 +74,7 @@ export default function AddWorkerModal({ open, onClose, onWorkerAdded }) {
         Object.entries(form).map(([key, value]) => {
           if (value === '') return [key, null];
           if (["a1", "epis", "desplazamiento"].includes(key)) return [key, Boolean(value)];
+          if (["salario_neto", "salario_bruto"].includes(key)) return [key, parseCurrency(value)];
           return [key, value];
         })
       );
@@ -156,8 +163,8 @@ export default function AddWorkerModal({ open, onClose, onWorkerAdded }) {
               {form.tipo_trabajador !== 'Fijo' &&
                 renderInput('Fecha de Baja', 'fecha_baja', '', 'date')}
               {renderInput('Horas Contratadas', 'horas_contratadas', 'Ej: 40', 'number')}
-              {renderInput('Salario Neto/Mes (€)', 'salario_neto', 'Ej: 1600', 'number')}
-              {renderInput('Salario Bruto/Mes (€)', 'salario_bruto', 'Ej: 1800', 'number')}
+              {renderInput('Salario Neto/Mes (€)', 'salario_neto', 'Ej: 1.600,50')}
+              {renderInput('Salario Bruto/Mes (€)', 'salario_bruto', 'Ej: 1.800,75')}
               {renderInput('Cliente', 'cliente', 'Ej: Indra, Amazon...')}
               {renderInput('País', 'pais', 'Ej: España')}
               {renderInput('Empresa', 'empresa', 'Ej: Construcciones S.A.')}

--- a/gestor-frontend/src/components/forms/EditWorkerModal.jsx
+++ b/gestor-frontend/src/components/forms/EditWorkerModal.jsx
@@ -1,18 +1,30 @@
 // src/components/forms/EditWorkerModal.jsx
 import React, { useState, useEffect } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
+import { parseCurrency, formatCurrency } from '@/utils/utils';
 
 export default function EditWorkerModal({ open, onClose, onWorkerUpdated, initialData }) {
   const [form, setForm] = useState({});
   const [formErrors, setFormErrors] = useState({});
 
   useEffect(() => {
-    if (initialData) setForm(initialData);
+    if (initialData) {
+      setForm({
+        ...initialData,
+        salario_neto: formatCurrency(initialData.salario_neto),
+        salario_bruto: formatCurrency(initialData.salario_bruto)
+      });
+    }
   }, [initialData]);
 
   const handleChange = (e) => {
     const { name, value, type, checked } = e.target;
-    setForm((prev) => ({ ...prev, [name]: type === 'checkbox' ? checked : value }));
+    if (["salario_neto", "salario_bruto"].includes(name)) {
+      const formatted = value.replace(/[^0-9.,]/g, "");
+      setForm((prev) => ({ ...prev, [name]: formatted }));
+    } else {
+      setForm((prev) => ({ ...prev, [name]: type === "checkbox" ? checked : value }));
+    }
     setFormErrors((prev) => ({ ...prev, [name]: undefined }));
   };
 
@@ -45,6 +57,7 @@ export default function EditWorkerModal({ open, onClose, onWorkerUpdated, initia
         Object.entries(form).map(([key, value]) => {
           if (value === '') return [key, null];
           if (["a1", "epis", "desplazamiento"].includes(key)) return [key, Boolean(value)];
+          if (["salario_neto", "salario_bruto"].includes(key)) return [key, parseCurrency(value)];
           return [key, value];
         })
       );
@@ -130,8 +143,8 @@ export default function EditWorkerModal({ open, onClose, onWorkerUpdated, initia
               {renderInput('Fecha de Alta', 'fecha_alta', '', 'date')}
               {form.tipo_trabajador !== 'Fijo' && renderInput('Fecha de Baja', 'fecha_baja', '', 'date')}
               {renderInput('Horas Contratadas', 'horas_contratadas', 'Ej: 40', 'number')}
-              {renderInput('Salario Neto/Mensual (€)', 'salario_neto', 'Ej: 1600', 'number')}
-              {renderInput('Salario Bruto/Mensual (€)', 'salario_bruto', 'Ej: 1800', 'number')}
+              {renderInput('Salario Neto/Mensual (€)', 'salario_neto', 'Ej: 1.600,50')}
+              {renderInput('Salario Bruto/Mensual (€)', 'salario_bruto', 'Ej: 1.800,75')}
               {renderInput('Cliente', 'cliente', 'Ej: Indra, Amazon...')}
               {renderInput('País', 'pais', 'Ej: España')}
               {renderInput('Empresa', 'empresa', 'Ej: Construcciones S.A.')}

--- a/gestor-frontend/src/utils/utils.js
+++ b/gestor-frontend/src/utils/utils.js
@@ -31,3 +31,22 @@ export const formatHoursToHM = (total) => {
   const minutes = Math.round((total - hours) * 60);
   return `${hours.toString().padStart(2, '0')}:${minutes.toString().padStart(2, '0')}h`;
 };
+
+export function formatCurrency(value) {
+  if (value === null || value === undefined || value === '') return '';
+  const number = typeof value === 'number' ? value : parseCurrency(value);
+  if (number === null) return '';
+  return new Intl.NumberFormat('es-ES', {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2
+  }).format(number);
+}
+
+export function parseCurrency(value) {
+  if (value === null || value === undefined || value === '') return null;
+  const str = String(value).replace(/[^0-9.,]/g, '');
+  if (str.includes(',')) {
+    return parseFloat(str.replace(/\./g, '').replace(',', '.'));
+  }
+  return parseFloat(str);
+}


### PR DESCRIPTION
## Summary
- add `formatCurrency` and `parseCurrency` helpers
- render salaries in european format on worker and stats screens
- accept salary input with periods for thousands and comma decimal

## Testing
- `npm --prefix gestor-frontend run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_688732024bf8832ba454eb1b2d453513