### PR TITLE
Add export buttons in summaries

### DIFF
--- a/gestor-frontend/src/components/HorasResumen.jsx
+++ b/gestor-frontend/src/components/HorasResumen.jsx
@@ -1,8 +1,9 @@
 // src/components/HorasResumen.jsx
 import React from 'react';
 import { motion } from 'framer-motion';
-import { Clock, Calendar } from 'lucide-react';
-import { getYear, getMonth, getDay, parseISO } from 'date-fns';
+import { Clock, Calendar, Download } from 'lucide-react';
+import { getYear, getMonth, getDay, parseISO, format } from 'date-fns';
+import { es } from 'date-fns/locale';
 import { calculateTotalHoursFromIntervals, formatHoursToHM } from '../utils/utils';
 
 
@@ -64,9 +65,10 @@ function calcularTipoHoras(intervals, dateKey, isFestivo, isVacaciones, isBaja) 
   return { normales, extras, nocturnas, festivas };
 }
 
-export function HoursSummary({ currentDate, scheduleData }) {
+export function HoursSummary({ currentDate, scheduleData, onDownload }) {
   const year = getYear(currentDate);
   const month = getMonth(currentDate);
+  const monthLabel = format(currentDate, 'MMMM', { locale: es });
   let resumen = { normales: 0, extras: 0, nocturnas: 0, festivas: 0 };
 
   Object.entries(scheduleData).forEach(([dateKey, entry]) => {
@@ -95,10 +97,21 @@ export function HoursSummary({ currentDate, scheduleData }) {
       transition={{ duration: 0.5, delay: 0.2 }}
       className="bg-gradient-to-br from-gray-50 to-gray-100 dark:from-gray-800 dark:to-gray-900 rounded-xl shadow-xl p-6 mt-6"
     >
-      <h3 className="text-xl font-semibold mb-4 flex items-center text-gray-800 dark:text-gray-200">
-        <Clock className="mr-2 h-6 w-6 text-blue-500" />
-        Resumen de Horas del Mes
-      </h3>
+      <div className="flex items-center justify-between mb-4">
+        <h3 className="text-xl font-semibold flex items-center text-gray-800 dark:text-gray-200">
+          <Clock className="mr-2 h-6 w-6 text-blue-500" />
+          Resumen de Horas del Mes
+        </h3>
+        {onDownload && (
+          <button
+            onClick={onDownload}
+            className="inline-flex items-center gap-2 px-3 py-1 text-sm font-medium text-gray-700 bg-white border rounded shadow hover:bg-gray-50"
+          >
+            <Download className="w-4 h-4" />
+            {`Descargar Plantilla (${monthLabel})`}
+          </button>
+        )}
+      </div>
 
       <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
         <div className="bg-white dark:bg-gray-700 rounded-lg p-4 shadow-md">

--- a/gestor-frontend/src/components/HorasResumenAnual.jsx
+++ b/gestor-frontend/src/components/HorasResumenAnual.jsx
@@ -1,8 +1,8 @@
 // src/components/HorasResumenAnual.jsx
 import React from 'react';
 import { motion } from 'framer-motion';
-import { Clock } from 'lucide-react';
-import { getYear, getDay, parseISO } from 'date-fns';
+import { Clock, Download } from 'lucide-react';
+import { getYear, getDay, parseISO, format } from 'date-fns';
 import { formatHoursToHM } from '../utils/utils';
 
 function calcularTipoHoras(intervals, dateKey, isFestivo, isVacaciones, isBaja) {
@@ -61,8 +61,9 @@ function calcularTipoHoras(intervals, dateKey, isFestivo, isVacaciones, isBaja) 
   return { normales, extras, nocturnas, festivas };
 }
 
-export function YearHoursSummary({ currentDate, scheduleData }) {
+export function YearHoursSummary({ currentDate, scheduleData, onDownload }) {
   const year = getYear(currentDate);
+  const yearLabel = format(currentDate, 'yyyy');
   let resumen = { normales: 0, extras: 0, nocturnas: 0, festivas: 0 };
 
   Object.entries(scheduleData).forEach(([dateKey, entry]) => {
@@ -92,10 +93,21 @@ export function YearHoursSummary({ currentDate, scheduleData }) {
       transition={{ duration: 0.5, delay: 0.2 }}
       className="bg-gradient-to-br from-gray-50 to-gray-100 dark:from-gray-800 dark:to-gray-900 rounded-xl shadow-xl p-6 mt-6"
     >
-      <h3 className="text-xl font-semibold mb-4 flex items-center text-gray-800 dark:text-gray-200">
-        <Clock className="mr-2 h-6 w-6 text-blue-500" />
-        Resumen de Horas del Año
-      </h3>
+      <div className="flex items-center justify-between mb-4">
+        <h3 className="text-xl font-semibold flex items-center text-gray-800 dark:text-gray-200">
+          <Clock className="mr-2 h-6 w-6 text-blue-500" />
+          Resumen de Horas del Año
+        </h3>
+        {onDownload && (
+          <button
+            onClick={onDownload}
+            className="inline-flex items-center gap-2 px-3 py-1 text-sm font-medium text-gray-700 bg-white border rounded shadow hover:bg-gray-50"
+          >
+            <Download className="w-4 h-4" />
+            {`Descargar Plantilla Anual (${yearLabel})`}
+          </button>
+        )}
+      </div>
 
       <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
         <div className="bg-white dark:bg-gray-700 rounded-lg p-4 shadow-md">

--- a/gestor-frontend/src/components/ScheduleManager.jsx
+++ b/gestor-frontend/src/components/ScheduleManager.jsx
@@ -8,7 +8,11 @@ import WorkerAutocomplete from '@/components/WorkerAutocomplete';
 import { HoursSummary } from '@/components/HorasResumen';
 import { YearHoursSummary } from '@/components/HorasResumenAnual';
 import { ChevronLeft, ChevronRight, Settings, Folder, Download } from 'lucide-react';
-import { exportScheduleToExcel, exportAllSchedulesToExcel } from '@/utils/exportExcel';
+import {
+  exportScheduleToExcel,
+  exportAllSchedulesToExcel,
+  exportYearScheduleToExcel
+} from '@/utils/exportExcel';
 
 export default function ScheduleManager() {
   const [trabajadores, setTrabajadores] = useState([]);
@@ -86,6 +90,25 @@ export default function ScheduleManager() {
       const trabajador = trabajadores.find(t => t.id === Number(selectedTrabajadorId));
       if (trabajador) {
         exportScheduleToExcel(trabajador, res.data, currentDate);
+      }
+    } catch (err) {
+      console.error('Error al generar Excel:', err);
+      alert('No se pudo generar el archivo');
+    }
+  };
+
+  const handleDescargarPlantillaAnual = async () => {
+    try {
+      const token = localStorage.getItem('token');
+      const res = await axios.get(
+        `${import.meta.env.VITE_API_URL}/horarios/${selectedTrabajadorId}`,
+        { headers: { Authorization: `Bearer ${token}` } }
+      );
+      const trabajador = trabajadores.find(
+        t => t.id === Number(selectedTrabajadorId)
+      );
+      if (trabajador) {
+        exportYearScheduleToExcel(trabajador, res.data, currentDate);
       }
     } catch (err) {
       console.error('Error al generar Excel:', err);
@@ -240,13 +263,6 @@ export default function ScheduleManager() {
             Festivos Globales
           </button>
           <button
-            onClick={handleDescargarPlantilla}
-            className="inline-flex items-center gap-2 px-4 py-2 text-sm font-medium text-gray-700 bg-white border rounded shadow hover:bg-gray-50"
-          >
-            <Download className="w-4 h-4" />
-            {`Descargar Plantilla (${format(currentDate, 'MMMM', { locale: es })})`}
-          </button>
-          <button
             onClick={handleDescargarTodasPlantillas}
             className="inline-flex items-center gap-2 px-4 py-2 text-sm font-medium text-gray-700 bg-white border rounded shadow hover:bg-gray-50"
           >
@@ -288,8 +304,16 @@ export default function ScheduleManager() {
         </div>
 
         <div className="max-w-5xl mx-auto">
-          <HoursSummary currentDate={currentDate} scheduleData={agruparHorarios(scheduleData)} />
-          <YearHoursSummary currentDate={currentDate} scheduleData={agruparHorarios(scheduleData)} />
+          <HoursSummary
+            currentDate={currentDate}
+            scheduleData={agruparHorarios(scheduleData)}
+            onDownload={handleDescargarPlantilla}
+          />
+          <YearHoursSummary
+            currentDate={currentDate}
+            scheduleData={agruparHorarios(scheduleData)}
+            onDownload={handleDescargarPlantillaAnual}
+          />
         </div>
       </div>
       <HorarioModal


### PR DESCRIPTION
## Summary
- allow customizing sheet name when building excel worksheets
- add yearly workbook exporter
- place monthly download button inside HoursSummary
- add new annual button inside YearHoursSummary
- connect new buttons from ScheduleManager

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68873ad4efdc832b8f321bc7a87d222b