### PR TITLE
Fix annual template download

### DIFF
--- a/gestor-frontend/src/utils/exportExcel.js
+++ b/gestor-frontend/src/utils/exportExcel.js
@@ -405,13 +405,14 @@ export async function exportYearScheduleToExcel(
   const year = format(yearDate, 'yyyy');
   for (let m = 0; m < 12; m++) {
     const monthDate = new Date(yearDate.getFullYear(), m, 1);
-    const sheetLabel = `${format(monthDate, 'MMM', { locale: es })}`;
+    const sheetLabel = format(monthDate, 'MMM', { locale: es });
+    const baseName = trabajador.nombre ? trabajador.nombre.substring(0, 27) : '';
     await addScheduleWorksheet(
       workbook,
       trabajador,
       horarios,
       monthDate,
-      `${trabajador.nombre}-${sheetLabel}`
+      `${baseName}-${sheetLabel}`
     );
   }
   const buffer = await workbook.xlsx.writeBuffer();


### PR DESCRIPTION
## Summary
- ensure worksheet names for yearly exports include the month even for long employee names

## Testing
- `npm run lint` *(fails: cannot find module '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68873f7984fc832b914faaa63d0a0e9d