### PR TITLE
Allow assigning projects without hours

### DIFF
--- a/gestor-backend/controllers/horario.controller.js
+++ b/gestor-backend/controllers/horario.controller.js
@@ -72,6 +72,19 @@ exports.createOrUpdateHorarios = async (req, res) => {
         proyecto_nombre: proyecto_nombre || null
       });
     }
+    // Permitir asignar un proyecto sin intervalos
+    else if (proyecto_nombre) {
+      nuevos.push({
+        trabajador_id,
+        fecha,
+        hora_inicio: '00:00:00',
+        hora_fin: '00:00:00',
+        festivo: false,
+        vacaciones: false,
+        bajamedica: false,
+        proyecto_nombre
+      });
+    }
 
     if (nuevos.length > 0) {
       await Horario.bulkCreate(nuevos);

--- a/gestor-frontend/src/components/ScheduleManager.jsx
+++ b/gestor-frontend/src/components/ScheduleManager.jsx
@@ -243,7 +243,14 @@ export default function ScheduleManager() {
             </>
           )}
 
-          {totalHoras === 0 && !festivo && !bajamedica && weekend && (
+          {totalHoras === 0 && !festivo && !bajamedica && eventos[0]?.proyecto_nombre && (
+            <div className="flex items-center gap-1 text-xs text-gray-500 mt-1">
+              <Folder className="w-4 h-4" />
+              <span className="truncate max-w-[6rem]">{eventos[0].proyecto_nombre}</span>
+            </div>
+          )}
+
+          {totalHoras === 0 && !festivo && !bajamedica && weekend && !eventos[0]?.proyecto_nombre && (
             <span className="text-xs italic absolute bottom-1 right-1 text-gray-400">Libre</span>
           )}
         </div>


### PR DESCRIPTION
## Summary
- allow creating a schedule entry with a project even when there are no intervals
- show project name on calendar days with zero hours

## Testing
- `npm --prefix gestor-frontend run lint` *(fails: Cannot find package '@eslint/js' because internet access is disabled)*


------
https://chatgpt.com/codex/tasks/task_e_68874514f520832ba4ba05c8f2861906