### PR TITLE
Display owed hours as negative

### DIFF
--- a/gestor-frontend/src/components/HorasResumen.jsx
+++ b/gestor-frontend/src/components/HorasResumen.jsx
@@ -153,7 +153,9 @@ export function HoursSummary({ currentDate, scheduleData, onDownload }) {
         <div className="flex justify-between items-center border-b pb-2">
           <span className="text-rose-600 font-medium">Horas a deber</span>
           <span className="text-md font-semibold text-rose-500">
-            {formatHoursToHM(resumen.adeber)}
+            {resumen.adeber > 0
+              ? `-${formatHoursToHM(resumen.adeber)}`
+              : formatHoursToHM(resumen.adeber)}
           </span>
         </div>
 

--- a/gestor-frontend/src/components/HorasResumenAnual.jsx
+++ b/gestor-frontend/src/components/HorasResumenAnual.jsx
@@ -149,7 +149,9 @@ export function YearHoursSummary({ currentDate, scheduleData, onDownload }) {
           <div className="flex justify-between items-center border-b pb-2">
             <span className="text-rose-600 font-medium">Horas a deber</span>
             <span className="text-md font-semibold text-rose-500">
-              {formatHoursToHM(resumen.adeber)}
+              {resumen.adeber > 0
+                ? `-${formatHoursToHM(resumen.adeber)}`
+                : formatHoursToHM(resumen.adeber)}
             </span>
           </div>
 


### PR DESCRIPTION
## Summary
- show negative sign for owed hours in monthly and annual summaries

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_688875acc2e8832b9a7afa3a11526113