### PR TITLE
Update salary formatting

### DIFF
--- a/gestor-frontend/src/components/forms/AddWorkerModal.jsx
+++ b/gestor-frontend/src/components/forms/AddWorkerModal.jsx
@@ -37,7 +37,7 @@ export default function AddWorkerModal({ open, onClose, onWorkerAdded }) {
   const handleChange = (e) => {
     const { name, value, type, checked } = e.target;
     if (["salario_neto", "salario_bruto"].includes(name)) {
-      const formatted = value.replace(/[^0-9.,]/g, "");
+      const formatted = value.replace(/[^0-9]/g, "");
       setForm((prev) => ({ ...prev, [name]: formatted }));
     } else {
       setForm((prev) => ({ ...prev, [name]: type === "checkbox" ? checked : value }));

--- a/gestor-frontend/src/components/forms/EditWorkerModal.jsx
+++ b/gestor-frontend/src/components/forms/EditWorkerModal.jsx
@@ -20,7 +20,7 @@ export default function EditWorkerModal({ open, onClose, onWorkerUpdated, initia
   const handleChange = (e) => {
     const { name, value, type, checked } = e.target;
     if (["salario_neto", "salario_bruto"].includes(name)) {
-      const formatted = value.replace(/[^0-9.,]/g, "");
+      const formatted = value.replace(/[^0-9]/g, "");
       setForm((prev) => ({ ...prev, [name]: formatted }));
     } else {
       setForm((prev) => ({ ...prev, [name]: type === "checkbox" ? checked : value }));

--- a/gestor-frontend/src/utils/utils.js
+++ b/gestor-frontend/src/utils/utils.js
@@ -37,16 +37,22 @@ export function formatCurrency(value) {
   const number = typeof value === 'number' ? value : parseCurrency(value);
   if (number === null) return '';
   return new Intl.NumberFormat('es-ES', {
-    minimumFractionDigits: 2,
-    maximumFractionDigits: 2
+    maximumFractionDigits: 0
   }).format(number);
 }
 
 export function parseCurrency(value) {
   if (value === null || value === undefined || value === '') return null;
   const str = String(value).replace(/[^0-9.,]/g, '');
-  if (str.includes(',')) {
-    return parseFloat(str.replace(/\./g, '').replace(',', '.'));
+  if (str === '') return null;
+
+  let number;
+  if (str.includes(',') || str.includes('.')) {
+    number = parseFloat(str.replace(/\./g, '').replace(',', '.'));
+  } else {
+    number = parseFloat(str);
   }
-  return parseFloat(str);
+
+  if (Number.isNaN(number)) return null;
+  return Math.trunc(number);
 }


### PR DESCRIPTION
## Summary
- format salary as integer with thousand separators
- parse salary values as integers
- restrict salary input to only digits

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@types%2freact)*

------
https://chatgpt.com/codex/tasks/task_e_68887ad366ac832ba9b1af7e631a6428