### PR TITLE
Improve salary currency formatting

### DIFF
--- a/gestor-frontend/src/utils/utils.js
+++ b/gestor-frontend/src/utils/utils.js
@@ -36,9 +36,10 @@ export function formatCurrency(value) {
   if (value === null || value === undefined || value === '') return '';
   const number = typeof value === 'number' ? value : parseCurrency(value);
   if (number === null) return '';
+  const hasDecimals = number % 1 !== 0;
   return new Intl.NumberFormat('es-ES', {
-    minimumFractionDigits: 2,
-    maximumFractionDigits: 2
+    minimumFractionDigits: hasDecimals ? 2 : 0,
+    maximumFractionDigits: hasDecimals ? 2 : 0
   }).format(number);
 }
 


### PR DESCRIPTION
## Summary
- avoid forcing decimal places when formatting salary amounts

## Testing
- `npm run lint` *(fails: cannot access npm registry)*

------
https://chatgpt.com/codex/tasks/task_e_68887cc831b0832bbbea7136d50bb52d