### PR TITLE
Fix currency thousand separator

### DIFF
--- a/gestor-frontend/src/utils/utils.js
+++ b/gestor-frontend/src/utils/utils.js
@@ -37,10 +37,10 @@ export function formatCurrency(value) {
   const number = typeof value === 'number' ? value : parseCurrency(value);
   if (number === null) return '';
   const hasDecimals = number % 1 !== 0;
-  return new Intl.NumberFormat('es-ES', {
-    minimumFractionDigits: hasDecimals ? 2 : 0,
-    maximumFractionDigits: hasDecimals ? 2 : 0
-  }).format(number);
+  const fixed = number.toFixed(hasDecimals ? 2 : 0);
+  let [intPart, decPart] = fixed.split('.');
+  intPart = intPart.replace(/\B(?=(\d{3})+(?!\d))/g, '.');
+  return decPart ? `${intPart},${decPart}` : intPart;
 }
 
 export function parseCurrency(value) {


### PR DESCRIPTION
## Summary
- ensure salary currency formatting uses dot thousand separator

## Testing
- `npm --prefix gestor-frontend run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68888b08f028832bb8692456e4701d66