### PR TITLE
Fix salary parsing with thousand separator

### DIFF
--- a/gestor-frontend/src/utils/utils.js
+++ b/gestor-frontend/src/utils/utils.js
@@ -49,5 +49,7 @@ export function parseCurrency(value) {
   if (str.includes(',')) {
     return parseFloat(str.replace(/\./g, '').replace(',', '.'));
   }
-  return parseFloat(str);
+  // If there are dots but no comma, they represent thousand separators
+  // so we strip them before parsing to avoid interpreting "1.000" as 1
+  return parseFloat(str.replace(/\./g, ''));
 }


### PR DESCRIPTION
## Summary
- handle salaries like `1.000` correctly when saving

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68888c4fc02c832bbbdf60b5fa0a5797