### PR TITLE
Fix currency parsing for dot decimal salaries

### DIFF
--- a/gestor-frontend/src/utils/utils.js
+++ b/gestor-frontend/src/utils/utils.js
@@ -49,6 +49,12 @@ export function parseCurrency(value) {
   if (str.includes(',')) {
     return parseFloat(str.replace(/\./g, '').replace(',', '.'));
   }
+  if (str.includes('.')) {
+    const parts = str.split('.');
+    if (parts.length === 2 && parts[1].length <= 2) {
+      return parseFloat(str);
+    }
+  }
   // If there are dots but no comma, they represent thousand separators
   // so we strip them before parsing to avoid interpreting "1.000" as 1
   return parseFloat(str.replace(/\./g, ''));


### PR DESCRIPTION
## Summary
- handle dot decimal salaries correctly

## Testing
- `npm test` (backend) – fails: no test specified
- `npm test` (frontend) – fails: missing script

------
https://chatgpt.com/codex/tasks/task_e_68888e2d8df4832b895bb84c4a29d11e