### PR TITLE
Add A1 and Limosa expiry alerts

### DIFF
--- a/db/backup_gestor_horarios.sql
+++ b/db/backup_gestor_horarios.sql
@@ -141,6 +141,9 @@ CREATE TABLE `trabajador` (
   `cliente` varchar(255) DEFAULT NULL,
   `a1` tinyint(1) DEFAULT '0',
   `fecha_limosa` date DEFAULT NULL,
+  `fechafin_limosa` date DEFAULT NULL,
+  `fecha_a1` date DEFAULT NULL,
+  `fechafin_a1` date DEFAULT NULL,
   `condiciones` text,
   `createdAt` datetime NOT NULL,
   `updatedAt` datetime NOT NULL,
@@ -160,7 +163,7 @@ CREATE TABLE `trabajador` (
 
 LOCK TABLES `trabajador` WRITE;
 /*!40000 ALTER TABLE `trabajador` DISABLE KEYS */;
-INSERT INTO `trabajador` VALUES (21,'Cesar Antonio Arenas Cañizales','27364083V','selazr@protonmail.com','722393061','Fijo','G1','Oficial 1','ES6112343456420456323532','123456789012','2000-01-12',NULL,40.00,1600.00,'Carrer de la sabateria 24',0,NULL,'No',0,NULL,NULL,'2025-05-27 07:03:51','2025-05-27 07:33:39','España',0,NULL,'Line-X Hispania');
+INSERT INTO `trabajador` VALUES (21,'Cesar Antonio Arenas Cañizales','27364083V','selazr@protonmail.com','722393061','Fijo','G1','Oficial 1','ES6112343456420456323532','123456789012','2000-01-12',NULL,40.00,1600.00,'Carrer de la sabateria 24',0,NULL,'No',0,NULL,NULL,NULL,NULL,NULL,'2025-05-27 07:03:51','2025-05-27 07:33:39','España',0,NULL,'Line-X Hispania');
 /*!40000 ALTER TABLE `trabajador` ENABLE KEYS */;
 UNLOCK TABLES;
 

--- a/gestor-backend/models/trabajador.model.js
+++ b/gestor-backend/models/trabajador.model.js
@@ -24,6 +24,9 @@ module.exports = (sequelize, DataTypes) => {
     epis: { type: DataTypes.BOOLEAN, defaultValue: false },
     fecha_epis: DataTypes.DATEONLY,
     fecha_limosa: DataTypes.DATEONLY,
+    fechafin_limosa: DataTypes.DATEONLY,
+    fecha_a1: DataTypes.DATEONLY,
+    fechafin_a1: DataTypes.DATEONLY,
     condiciones: DataTypes.TEXT
   }, {
     freezeTableName: true // 👈 esto evita la pluralización (Trabajadors)

--- a/gestor-frontend/src/components/Header.jsx
+++ b/gestor-frontend/src/components/Header.jsx
@@ -36,10 +36,44 @@ export default function Header() {
           { headers: { Authorization: `Bearer ${token}` } }
         );
         const today = new Date();
-        const upcoming = res.data.filter((w) => {
-          if (!w.fecha_baja) return false;
-          const diff = (new Date(w.fecha_baja) - today) / (1000 * 60 * 60 * 24);
-          return diff >= 0 && diff <= 7;
+        const upcoming = [];
+        res.data.forEach((w) => {
+          if (w.fecha_baja) {
+            const diff = (new Date(w.fecha_baja) - today) / (1000 * 60 * 60 * 24);
+            if (diff >= 0 && diff <= 7) {
+              const dias = Math.ceil(diff);
+              const mensaje = dias === 7
+                ? `A ${w.nombre} le queda 1 semana de contrato`
+                : dias === 1
+                  ? `A ${w.nombre} le queda 1 día de contrato`
+                  : `A ${w.nombre} le quedan ${dias} días de contrato`;
+              upcoming.push({ id: `baja-${w.id}`, mensaje });
+            }
+          }
+          if (w.fechafin_limosa) {
+            const diff = (new Date(w.fechafin_limosa) - today) / (1000 * 60 * 60 * 24);
+            if (diff >= 0 && diff <= 7) {
+              const dias = Math.ceil(diff);
+              const mensaje = dias === 7
+                ? `La Limosa de ${w.nombre} vence en 1 semana`
+                : dias === 1
+                  ? `La Limosa de ${w.nombre} vence en 1 día`
+                  : `La Limosa de ${w.nombre} vence en ${dias} días`;
+              upcoming.push({ id: `limosa-${w.id}`, mensaje });
+            }
+          }
+          if (w.fechafin_a1) {
+            const diff = (new Date(w.fechafin_a1) - today) / (1000 * 60 * 60 * 24);
+            if (diff >= 0 && diff <= 7) {
+              const dias = Math.ceil(diff);
+              const mensaje = dias === 7
+                ? `El A1 de ${w.nombre} vence en 1 semana`
+                : dias === 1
+                  ? `El A1 de ${w.nombre} vence en 1 día`
+                  : `El A1 de ${w.nombre} vence en ${dias} días`;
+              upcoming.push({ id: `a1-${w.id}`, mensaje });
+            }
+          }
         });
         setNotifications(upcoming);
       } catch (err) {
@@ -119,19 +153,11 @@ export default function Header() {
                     {notifications.length === 0 && (
                       <div className="px-4 py-2 text-sm">Sin notificaciones</div>
                     )}
-                    {notifications.map((n) => {
-                      const diff = Math.ceil((new Date(n.fecha_baja) - new Date()) / 86400000);
-                      const mensaje = diff === 7
-                        ? `A ${n.nombre} le queda 1 semana de contrato`
-                        : diff === 1
-                          ? `A ${n.nombre} le queda 1 día de contrato`
-                          : `A ${n.nombre} le quedan ${diff} días de contrato`;
-                      return (
-                        <div key={n.id} className="px-4 py-2 text-sm border-b last:border-b-0">
-                          {mensaje}
-                        </div>
-                      );
-                    })}
+                    {notifications.map((n) => (
+                      <div key={n.id} className="px-4 py-2 text-sm border-b last:border-b-0">
+                        {n.mensaje}
+                      </div>
+                    ))}
                   </motion.div>
                 )}
               </AnimatePresence>
@@ -169,19 +195,11 @@ export default function Header() {
                     {notifications.length === 0 && (
                       <div className="px-4 py-2 text-sm">Sin notificaciones</div>
                     )}
-                    {notifications.map((n) => {
-                      const diff = Math.ceil((new Date(n.fecha_baja) - new Date()) / 86400000);
-                      const mensaje = diff === 7
-                        ? `A ${n.nombre} le queda 1 semana de contrato`
-                        : diff === 1
-                          ? `A ${n.nombre} le queda 1 día de contrato`
-                          : `A ${n.nombre} le quedan ${diff} días de contrato`;
-                      return (
-                        <div key={n.id} className="px-4 py-2 text-sm border-b last:border-b-0">
-                          {mensaje}
-                        </div>
-                      );
-                    })}
+                    {notifications.map((n) => (
+                      <div key={n.id} className="px-4 py-2 text-sm border-b last:border-b-0">
+                        {n.mensaje}
+                      </div>
+                    ))}
                   </motion.div>
                 )}
               </AnimatePresence>

--- a/gestor-frontend/src/components/Trabajador.jsx
+++ b/gestor-frontend/src/components/Trabajador.jsx
@@ -255,7 +255,10 @@ const handleBaja = async (id) => {
                     <p><Euro className="inline w-4 h-4 mr-1 text-emerald-300" /> Salario Bruto: {formatCurrency(t.salario_bruto)} €</p>
                     <p><User className="inline w-4 h-4 mr-1 text-red-500" /> Cliente: {t.cliente}</p>
                     <p>A1: {t.a1 ? 'Sí' : 'No'}</p>
-                    <p>Fecha A1: {t.fecha_limosa ? formatDate(t.fecha_limosa) : 'N/A'}</p>
+                    <p>Fecha Limosa: {t.fecha_limosa ? formatDate(t.fecha_limosa) : 'N/A'}</p>
+                    <p>Fin Limosa: {t.fechafin_limosa ? formatDate(t.fechafin_limosa) : 'N/A'}</p>
+                    <p>Fecha A1: {t.fecha_a1 ? formatDate(t.fecha_a1) : 'N/A'}</p>
+                    <p>Fin A1: {t.fechafin_a1 ? formatDate(t.fechafin_a1) : 'N/A'}</p>
                     <p>Desplazamiento: {t.desplazamiento ? 'Sí' : 'No'}</p>
                     <p>Fecha Desplazamiento: {t.fecha_desplazamiento ? formatDate(t.fecha_desplazamiento) : 'N/A'}</p>
                     <p><HardHat className="inline w-4 h-4 mr-1 text-yellow-600" /> EPIs: {t.epis ? 'Sí' : 'No'}</p>

--- a/gestor-frontend/src/components/forms/AddWorkerModal.jsx
+++ b/gestor-frontend/src/components/forms/AddWorkerModal.jsx
@@ -25,6 +25,9 @@ export default function AddWorkerModal({ open, onClose, onWorkerAdded }) {
     cliente: '',
     a1: false,
     fecha_limosa: '',
+    fechafin_limosa: '',
+    fecha_a1: '',
+    fechafin_a1: '',
     condiciones: '',
     pais: '',
     epis: false,
@@ -65,7 +68,10 @@ export default function AddWorkerModal({ open, onClose, onWorkerAdded }) {
     if (!form.horas_contratadas) errors.horas_contratadas = 'Las horas contratadas son obligatorias';
     if (!form.salario_neto) errors.salario_neto = 'El salario neto mensual es obligatorio';
     if (!form.salario_bruto) errors.salario_bruto = 'El salario bruto mensual es obligatorio';
-    if (form.a1 && !form.fecha_limosa) errors.fecha_limosa = 'Debe especificar la fecha A1';
+    if (form.a1 && !form.fecha_limosa) errors.fecha_limosa = 'Debe especificar la fecha Limosa';
+    if (form.a1 && !form.fechafin_limosa) errors.fechafin_limosa = 'Debe especificar la fecha fin Limosa';
+    if (form.a1 && !form.fecha_a1) errors.fecha_a1 = 'Debe especificar la fecha A1';
+    if (form.a1 && !form.fechafin_a1) errors.fechafin_a1 = 'Debe especificar la fecha fin A1';
     if (form.epis && !form.fecha_epis) errors.fecha_epis = 'Debe especificar la fecha de EPIs';
     if (form.desplazamiento && !form.fecha_desplazamiento) errors.fecha_desplazamiento = 'Debe especificar la fecha de desplazamiento';
     return errors;
@@ -182,7 +188,10 @@ export default function AddWorkerModal({ open, onClose, onWorkerAdded }) {
               <label className="flex items-center gap-2 col-span-full">
                 <input type="checkbox" name="a1" checked={form.a1} onChange={handleChange} /> ¿Tiene A1?
               </label>
-              {form.a1 && renderInput('Fecha A1', 'fecha_limosa', '', 'date')}
+              {form.a1 && renderInput('Fecha Limosa', 'fecha_limosa', '', 'date')}
+              {form.a1 && renderInput('Fin Limosa', 'fechafin_limosa', '', 'date')}
+              {form.a1 && renderInput('Fecha A1', 'fecha_a1', '', 'date')}
+              {form.a1 && renderInput('Fin A1', 'fechafin_a1', '', 'date')}
               <label className="flex items-center gap-2 col-span-full">
                 <input type="checkbox" name="epis" checked={form.epis} onChange={handleChange} /> ¿Tiene EPIs?
               </label>

--- a/gestor-frontend/src/components/forms/EditWorkerModal.jsx
+++ b/gestor-frontend/src/components/forms/EditWorkerModal.jsx
@@ -48,7 +48,10 @@ export default function EditWorkerModal({ open, onClose, onWorkerUpdated, initia
     if (!form.horas_contratadas) errors.horas_contratadas = 'Las horas contratadas son obligatorias';
     if (!form.salario_neto) errors.salario_neto = 'El salario neto mensual es obligatorio';
     if (!form.salario_bruto) errors.salario_bruto = 'El salario bruto mensual es obligatorio';
-    if (form.a1 && !form.fecha_limosa) errors.fecha_limosa = 'Debe especificar la fecha A1';
+    if (form.a1 && !form.fecha_limosa) errors.fecha_limosa = 'Debe especificar la fecha Limosa';
+    if (form.a1 && !form.fechafin_limosa) errors.fechafin_limosa = 'Debe especificar la fecha fin Limosa';
+    if (form.a1 && !form.fecha_a1) errors.fecha_a1 = 'Debe especificar la fecha A1';
+    if (form.a1 && !form.fechafin_a1) errors.fechafin_a1 = 'Debe especificar la fecha fin A1';
     if (form.epis && !form.fecha_epis) errors.fecha_epis = 'Debe especificar la fecha de EPIs';
     if (form.desplazamiento && !form.fecha_desplazamiento) errors.fecha_desplazamiento = 'Debe especificar la fecha de desplazamiento';
     return errors;
@@ -162,7 +165,10 @@ export default function EditWorkerModal({ open, onClose, onWorkerUpdated, initia
               <label className="flex items-center gap-2 col-span-full">
                 <input type="checkbox" name="a1" checked={form.a1} onChange={handleChange} /> ¿Tiene A1?
               </label>
-              {form.a1 && renderInput('Fecha A1', 'fecha_limosa', '', 'date')}
+              {form.a1 && renderInput('Fecha Limosa', 'fecha_limosa', '', 'date')}
+              {form.a1 && renderInput('Fin Limosa', 'fechafin_limosa', '', 'date')}
+              {form.a1 && renderInput('Fecha A1', 'fecha_a1', '', 'date')}
+              {form.a1 && renderInput('Fin A1', 'fechafin_a1', '', 'date')}
               <label className="flex items-center gap-2 col-span-full">
                 <input type="checkbox" name="epis" checked={form.epis} onChange={handleChange} /> ¿Tiene EPIs?
               </label>


### PR DESCRIPTION
## Summary
- support new columns for Limosa and A1 expiry
- show Limosa and A1 dates in worker forms and details
- notify when Limosa/A1 are about to expire
- update DB schema dump

## Testing
- `npm --prefix gestor-frontend run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_688894b423b4832bbcd21a4ba07e4dd9