### PR TITLE
Add limosa toggle after A1

### DIFF
--- a/db/backup_gestor_horarios.sql
+++ b/db/backup_gestor_horarios.sql
@@ -140,10 +140,11 @@ CREATE TABLE `trabajador` (
   `fecha_desplazamiento` date DEFAULT NULL,
   `cliente` varchar(255) DEFAULT NULL,
   `a1` tinyint(1) DEFAULT '0',
-  `fecha_limosa` date DEFAULT NULL,
-  `fechafin_limosa` date DEFAULT NULL,
+  `limosa` tinyint(1) DEFAULT '0',
   `fecha_a1` date DEFAULT NULL,
   `fechafin_a1` date DEFAULT NULL,
+  `fecha_limosa` date DEFAULT NULL,
+  `fechafin_limosa` date DEFAULT NULL,
   `condiciones` text,
   `createdAt` datetime NOT NULL,
   `updatedAt` datetime NOT NULL,
@@ -163,7 +164,7 @@ CREATE TABLE `trabajador` (
 
 LOCK TABLES `trabajador` WRITE;
 /*!40000 ALTER TABLE `trabajador` DISABLE KEYS */;
-INSERT INTO `trabajador` VALUES (21,'Cesar Antonio Arenas Cañizales','27364083V','selazr@protonmail.com','722393061','Fijo','G1','Oficial 1','ES6112343456420456323532','123456789012','2000-01-12',NULL,40.00,1600.00,'Carrer de la sabateria 24',0,NULL,'No',0,NULL,NULL,NULL,NULL,NULL,'2025-05-27 07:03:51','2025-05-27 07:33:39','España',0,NULL,'Line-X Hispania');
+INSERT INTO `trabajador` VALUES (21,'Cesar Antonio Arenas Cañizales','27364083V','selazr@protonmail.com','722393061','Fijo','G1','Oficial 1','ES6112343456420456323532','123456789012','2000-01-12',NULL,40.00,1600.00,'Carrer de la sabateria 24',0,NULL,'No',0,0,NULL,NULL,NULL,NULL,NULL,'2025-05-27 07:03:51','2025-05-27 07:33:39','España',0,NULL,'Line-X Hispania');
 /*!40000 ALTER TABLE `trabajador` ENABLE KEYS */;
 UNLOCK TABLES;
 

--- a/gestor-backend/models/trabajador.model.js
+++ b/gestor-backend/models/trabajador.model.js
@@ -18,7 +18,8 @@ module.exports = (sequelize, DataTypes) => {
     desplazamiento: { type: DataTypes.BOOLEAN, defaultValue: false },
     fecha_desplazamiento: DataTypes.DATEONLY,
     cliente: DataTypes.STRING,
-    a1: { type: DataTypes.BOOLEAN, defaultValue: false }, // antes era limosa
+    a1: { type: DataTypes.BOOLEAN, defaultValue: false },
+    limosa: { type: DataTypes.BOOLEAN, defaultValue: false },
     pais: DataTypes.STRING,
     empresa: DataTypes.STRING,
     epis: { type: DataTypes.BOOLEAN, defaultValue: false },

--- a/gestor-frontend/src/components/Trabajador.jsx
+++ b/gestor-frontend/src/components/Trabajador.jsx
@@ -256,10 +256,19 @@ const handleBaja = async (id) => {
                     <p><Euro className="inline w-4 h-4 mr-1 text-emerald-300" /> Salario Bruto: {formatCurrency(t.salario_bruto)} €</p>
                     <p><User className="inline w-4 h-4 mr-1 text-red-500" /> Cliente: {t.cliente}</p>
                     <p>A1: {t.a1 ? 'Sí' : 'No'}</p>
-                    <p>Fecha Limosa: {t.fecha_limosa ? formatDate(t.fecha_limosa) : 'N/A'}</p>
-                    <p>Fin Limosa: {t.fechafin_limosa ? formatDate(t.fechafin_limosa) : 'N/A'}</p>
-                    <p>Fecha A1: {t.fecha_a1 ? formatDate(t.fecha_a1) : 'N/A'}</p>
-                    <p>Fin A1: {t.fechafin_a1 ? formatDate(t.fechafin_a1) : 'N/A'}</p>
+                    {t.a1 && (
+                      <>
+                        <p>Fecha A1: {t.fecha_a1 ? formatDate(t.fecha_a1) : 'N/A'}</p>
+                        <p>Fin A1: {t.fechafin_a1 ? formatDate(t.fechafin_a1) : 'N/A'}</p>
+                        <p>Limosa: {t.limosa ? 'Sí' : 'No'}</p>
+                        {t.limosa && (
+                          <>
+                            <p>Fecha Limosa: {t.fecha_limosa ? formatDate(t.fecha_limosa) : 'N/A'}</p>
+                            <p>Fin Limosa: {t.fechafin_limosa ? formatDate(t.fechafin_limosa) : 'N/A'}</p>
+                          </>
+                        )}
+                      </>
+                    )}
                     <p>Desplazamiento: {t.desplazamiento ? 'Sí' : 'No'}</p>
                     <p>Fecha Desplazamiento: {t.fecha_desplazamiento ? formatDate(t.fecha_desplazamiento) : 'N/A'}</p>
                     <p><HardHat className="inline w-4 h-4 mr-1 text-yellow-600" /> EPIs: {t.epis ? 'Sí' : 'No'}</p>

--- a/gestor-frontend/src/components/forms/AddWorkerModal.jsx
+++ b/gestor-frontend/src/components/forms/AddWorkerModal.jsx
@@ -24,6 +24,7 @@ export default function AddWorkerModal({ open, onClose, onWorkerAdded }) {
     fecha_desplazamiento: '',
     cliente: '',
     a1: false,
+    limosa: false,
     fecha_limosa: '',
     fechafin_limosa: '',
     fecha_a1: '',
@@ -68,8 +69,8 @@ export default function AddWorkerModal({ open, onClose, onWorkerAdded }) {
     if (!form.horas_contratadas) errors.horas_contratadas = 'Las horas contratadas son obligatorias';
     if (!form.salario_neto) errors.salario_neto = 'El salario neto mensual es obligatorio';
     if (!form.salario_bruto) errors.salario_bruto = 'El salario bruto mensual es obligatorio';
-    if (form.a1 && !form.fecha_limosa) errors.fecha_limosa = 'Debe especificar la fecha Limosa';
-    if (form.a1 && !form.fechafin_limosa) errors.fechafin_limosa = 'Debe especificar la fecha fin Limosa';
+    if (form.limosa && !form.fecha_limosa) errors.fecha_limosa = 'Debe especificar la fecha Limosa';
+    if (form.limosa && !form.fechafin_limosa) errors.fechafin_limosa = 'Debe especificar la fecha fin Limosa';
     if (form.a1 && !form.fecha_a1) errors.fecha_a1 = 'Debe especificar la fecha A1';
     if (form.a1 && !form.fechafin_a1) errors.fechafin_a1 = 'Debe especificar la fecha fin A1';
     if (form.epis && !form.fecha_epis) errors.fecha_epis = 'Debe especificar la fecha de EPIs';
@@ -89,7 +90,7 @@ export default function AddWorkerModal({ open, onClose, onWorkerAdded }) {
       const parsedForm = Object.fromEntries(
         Object.entries(form).map(([key, value]) => {
           if (value === '') return [key, null];
-          if (["a1", "epis", "desplazamiento"].includes(key)) return [key, Boolean(value)];
+          if (["a1", "limosa", "epis", "desplazamiento"].includes(key)) return [key, Boolean(value)];
           if (["salario_neto", "salario_bruto"].includes(key)) return [key, parseCurrency(value)];
           return [key, value];
         })
@@ -188,10 +189,17 @@ export default function AddWorkerModal({ open, onClose, onWorkerAdded }) {
               <label className="flex items-center gap-2 col-span-full">
                 <input type="checkbox" name="a1" checked={form.a1} onChange={handleChange} /> ¿Tiene A1?
               </label>
-              {form.a1 && renderInput('Fecha Limosa', 'fecha_limosa', '', 'date')}
-              {form.a1 && renderInput('Fin Limosa', 'fechafin_limosa', '', 'date')}
               {form.a1 && renderInput('Fecha A1', 'fecha_a1', '', 'date')}
               {form.a1 && renderInput('Fin A1', 'fechafin_a1', '', 'date')}
+              {form.a1 && (
+                <>
+                  <label className="flex items-center gap-2 col-span-full">
+                    <input type="checkbox" name="limosa" checked={form.limosa} onChange={handleChange} /> ¿Tiene Limosa?
+                  </label>
+                  {form.limosa && renderInput('Fecha Limosa', 'fecha_limosa', '', 'date')}
+                  {form.limosa && renderInput('Fin Limosa', 'fechafin_limosa', '', 'date')}
+                </>
+              )}
               <label className="flex items-center gap-2 col-span-full">
                 <input type="checkbox" name="epis" checked={form.epis} onChange={handleChange} /> ¿Tiene EPIs?
               </label>

--- a/gestor-frontend/src/components/forms/EditWorkerModal.jsx
+++ b/gestor-frontend/src/components/forms/EditWorkerModal.jsx
@@ -48,8 +48,8 @@ export default function EditWorkerModal({ open, onClose, onWorkerUpdated, initia
     if (!form.horas_contratadas) errors.horas_contratadas = 'Las horas contratadas son obligatorias';
     if (!form.salario_neto) errors.salario_neto = 'El salario neto mensual es obligatorio';
     if (!form.salario_bruto) errors.salario_bruto = 'El salario bruto mensual es obligatorio';
-    if (form.a1 && !form.fecha_limosa) errors.fecha_limosa = 'Debe especificar la fecha Limosa';
-    if (form.a1 && !form.fechafin_limosa) errors.fechafin_limosa = 'Debe especificar la fecha fin Limosa';
+    if (form.limosa && !form.fecha_limosa) errors.fecha_limosa = 'Debe especificar la fecha Limosa';
+    if (form.limosa && !form.fechafin_limosa) errors.fechafin_limosa = 'Debe especificar la fecha fin Limosa';
     if (form.a1 && !form.fecha_a1) errors.fecha_a1 = 'Debe especificar la fecha A1';
     if (form.a1 && !form.fechafin_a1) errors.fechafin_a1 = 'Debe especificar la fecha fin A1';
     if (form.epis && !form.fecha_epis) errors.fecha_epis = 'Debe especificar la fecha de EPIs';
@@ -69,7 +69,7 @@ export default function EditWorkerModal({ open, onClose, onWorkerUpdated, initia
       const parsedForm = Object.fromEntries(
         Object.entries(form).map(([key, value]) => {
           if (value === '') return [key, null];
-          if (["a1", "epis", "desplazamiento"].includes(key)) return [key, Boolean(value)];
+          if (["a1", "limosa", "epis", "desplazamiento"].includes(key)) return [key, Boolean(value)];
           if (["salario_neto", "salario_bruto"].includes(key)) return [key, parseCurrency(value)];
           return [key, value];
         })
@@ -165,10 +165,17 @@ export default function EditWorkerModal({ open, onClose, onWorkerUpdated, initia
               <label className="flex items-center gap-2 col-span-full">
                 <input type="checkbox" name="a1" checked={form.a1} onChange={handleChange} /> ¿Tiene A1?
               </label>
-              {form.a1 && renderInput('Fecha Limosa', 'fecha_limosa', '', 'date')}
-              {form.a1 && renderInput('Fin Limosa', 'fechafin_limosa', '', 'date')}
               {form.a1 && renderInput('Fecha A1', 'fecha_a1', '', 'date')}
               {form.a1 && renderInput('Fin A1', 'fechafin_a1', '', 'date')}
+              {form.a1 && (
+                <>
+                  <label className="flex items-center gap-2 col-span-full">
+                    <input type="checkbox" name="limosa" checked={form.limosa} onChange={handleChange} /> ¿Tiene Limosa?
+                  </label>
+                  {form.limosa && renderInput('Fecha Limosa', 'fecha_limosa', '', 'date')}
+                  {form.limosa && renderInput('Fin Limosa', 'fechafin_limosa', '', 'date')}
+                </>
+              )}
               <label className="flex items-center gap-2 col-span-full">
                 <input type="checkbox" name="epis" checked={form.epis} onChange={handleChange} /> ¿Tiene EPIs?
               </label>

--- a/gestor-frontend/src/utils/exportWorkerExcel.js
+++ b/gestor-frontend/src/utils/exportWorkerExcel.js
@@ -5,7 +5,8 @@ export function exportWorkerToExcel(trabajador, filePath) {
     'nombre', 'dni', 'correo_electronico', 'telefono', 'tipo_trabajador',
     'grupo', 'categoria', 'iban', 'nss', 'fecha_alta', 'fecha_baja',
     'horas_contratadas', 'salario_neto', 'salario_bruto', 'direccion',
-    'desplazamiento', 'fecha_desplazamiento', 'cliente', 'a1', 'fecha_limosa',
+    'desplazamiento', 'fecha_desplazamiento', 'cliente', 'a1', 'limosa',
+    'fecha_a1', 'fechafin_a1', 'fecha_limosa', 'fechafin_limosa',
     'condiciones', 'pais', 'epis', 'fecha_epis', 'empresa'
   ];
 


### PR DESCRIPTION
## Summary
- add `limosa` boolean column to DB backup and model
- show Limosa question only when A1 is selected and toggle its dates
- display Limosa info for workers
- include new fields in Excel export

## Testing
- `npm --prefix gestor-backend test` *(fails: Error: no test specified)*
- `npm --prefix gestor-frontend run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6888a45c4c10832ba556dfdccf861f12