### PR TITLE
Fix white text in worker dropdown

### DIFF
--- a/gestor-frontend/src/components/WorkerAutocomplete.jsx
+++ b/gestor-frontend/src/components/WorkerAutocomplete.jsx
@@ -38,7 +38,7 @@ export default function WorkerAutocomplete({ workers = [], selectedId, onChange 
           {filtered.map((w) => (
             <li
               key={w.id}
-              className="px-3 py-2 hover:bg-gray-100 cursor-pointer"
+              className="px-3 py-2 hover:bg-gray-100 cursor-pointer text-black"
               onMouseDown={() => handleSelect(w)}
             >
               {w.nombre}


### PR DESCRIPTION
## Summary
- ensure dropdown items render in black text

## Testing
- `npm run lint` *(fails: cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6888d4b042f8832bbe4ca2f171f4f133