### PR TITLE
Fix date range when exporting schedules

### DIFF
--- a/gestor-frontend/src/utils/exportExcel.js
+++ b/gestor-frontend/src/utils/exportExcel.js
@@ -116,7 +116,7 @@ export async function addScheduleWorksheet(
   const daysInMonth = new Date(year, month + 1, 0).getDate();
   for (let d = 1; d <= daysInMonth; d++) {
     const date = new Date(year, month, d);
-    const iso = date.toISOString().slice(0, 10);
+    const iso = format(date, 'yyyy-MM-dd');
     if (!dayData[iso]) {
       dayData[iso] = { total: 0, festivo: false, vacaciones: false, baja: false, intervals: [], horanegativa: 0, dianegativo: false };
     }


### PR DESCRIPTION
## Summary
- handle month dates in the user's timezone when creating the blank days in Excel exports

## Testing
- `npm run lint` *(fails: cannot download npm packages)*

------
https://chatgpt.com/codex/tasks/task_e_6888d814b99c832ba5d17c438c446a7e