### PR TITLE
Add organization statistics section

### DIFF
--- a/gestor-backend/routes/trabajador.routes.js
+++ b/gestor-backend/routes/trabajador.routes.js
@@ -5,6 +5,7 @@ const trabajadorController = require('../controllers/trabajador.controller');
 
 router.get('/', auth, trabajadorController.getAll);
 router.get('/estadisticas', auth, trabajadorController.getStats);
+router.get('/organizacion', auth, trabajadorController.getOrganizationInfo);
 router.get('/:id', auth, trabajadorController.getById);
 router.post('/', auth, trabajadorController.create);
 router.put('/:id', auth, trabajadorController.update);

--- a/gestor-frontend/src/App.jsx
+++ b/gestor-frontend/src/App.jsx
@@ -3,6 +3,7 @@ import Login from './components/Login';
 import Trabajador from './components/Trabajador';
 import ScheduleManager from './components/ScheduleManager';
 import Proyecciones from './components/Proyecciones';
+import Organizacion from './components/Organizacion';
 
 function App() {
   return (
@@ -12,6 +13,7 @@ function App() {
         <Route path="/trabajador" element={<Trabajador />} />
         <Route path="/dashboard" element={<ScheduleManager />} />
         <Route path="/proyecciones" element={<Proyecciones />} />
+        <Route path="/organizacion" element={<Organizacion />} />
       </Routes>
     </Router>
   );

--- a/gestor-frontend/src/components/Header.jsx
+++ b/gestor-frontend/src/components/Header.jsx
@@ -6,6 +6,7 @@ import {
   CalendarClock,
   Users,
   TrendingUp,
+  Building2,
   Menu,
   Bell
 } from 'lucide-react';
@@ -125,6 +126,10 @@ export default function Header() {
                   <TrendingUp className="mr-2 h-5 w-5" />
                   Proyecciones
                 </NavLink>
+                <NavLink to="/organizacion" className={navLinkClasses}>
+                  <Building2 className="mr-2 h-5 w-5" />
+                  Organización
+                </NavLink>
               </div>
             </nav>
           </div>
@@ -232,6 +237,9 @@ export default function Header() {
               </NavLink>
               <NavLink to="/proyecciones" className={navLinkClasses}>
                 <TrendingUp className="mr-2 h-5 w-5" /> Proyecciones
+              </NavLink>
+              <NavLink to="/organizacion" className={navLinkClasses}>
+                <Building2 className="mr-2 h-5 w-5" /> Organización
               </NavLink>
               <button
                 onClick={handleLogout}

--- a/gestor-frontend/src/components/Organizacion.jsx
+++ b/gestor-frontend/src/components/Organizacion.jsx
@@ -1,0 +1,89 @@
+import { useEffect, useState } from 'react';
+import axios from 'axios';
+import Header from '@/components/Header';
+
+export default function Organizacion() {
+  const [stats, setStats] = useState(null);
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    const fetchStats = async () => {
+      try {
+        const token = localStorage.getItem('token');
+        const res = await axios.get(`${import.meta.env.VITE_API_URL}/trabajadores/organizacion`, {
+          headers: { Authorization: `Bearer ${token}` }
+        });
+        setStats(res.data);
+      } catch (err) {
+        console.error(err);
+        setError('No se pudieron cargar las estadísticas de organización');
+      }
+    };
+
+    fetchStats();
+  }, []);
+
+  return (
+    <>
+      <Header />
+      <div className="min-h-screen bg-slate-100 p-6">
+        <div className="max-w-5xl mx-auto mb-6 text-center">
+          <h1 className="text-4xl font-bold bg-gradient-to-r from-blue-600 to-purple-500 bg-clip-text text-transparent">
+            Organización
+          </h1>
+          <p className="text-gray-600 mt-2">Resumen de empresas, países y antigüedad.</p>
+        </div>
+
+        {error && (
+          <div className="max-w-5xl mx-auto mb-4 bg-red-100 text-red-700 p-4 rounded shadow">
+            {error}
+          </div>
+        )}
+
+        {!stats ? (
+          <p className="text-center text-gray-600 mt-12">Cargando datos...</p>
+        ) : (
+          <>
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-6 max-w-5xl mx-auto">
+              <div className="bg-white p-6 rounded-xl shadow">
+                <h2 className="text-lg font-semibold mb-4">Trabajadores por empresa</h2>
+                <ul className="space-y-2">
+                  {stats.porEmpresa.map((e) => (
+                    <li key={e.empresa} className="flex justify-between">
+                      <span>{e.empresa || 'Sin especificar'}</span>
+                      <span className="font-bold">{e.count}</span>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+
+              <div className="bg-white p-6 rounded-xl shadow">
+                <h2 className="text-lg font-semibold mb-4">Trabajadores por país</h2>
+                <ul className="space-y-2">
+                  {stats.porPais.map((p) => (
+                    <li key={p.pais} className="flex justify-between">
+                      <span>{p.pais || 'Sin especificar'}</span>
+                      <span className="font-bold">{p.count}</span>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            </div>
+
+            <div className="max-w-5xl mx-auto mt-6 bg-white p-6 rounded-xl shadow">
+              <h2 className="text-lg font-semibold mb-4">Trabajadores con más antigüedad</h2>
+              <ul className="space-y-2">
+                {stats.veteranos.map((v) => (
+                  <li key={v.id} className="flex justify-between">
+                    <span>{v.nombre}</span>
+                    <span className="font-bold">{v.antiguedad} años</span>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          </>
+        )}
+      </div>
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
- backend: add `getOrganizationInfo` endpoint and route to return employee distribution by company and country plus longest-serving workers
- frontend: create `Organizacion` page to display new stats
- expose route in the router and navigation header

## Testing
- `npm --prefix gestor-frontend run lint` *(fails: Cannot find package '@eslint/js')*
- `npm --prefix gestor-backend test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6888e0ab63dc832b82c3405dc077e550