### PR TITLE
Filtra estadísticas de organización a trabajadores activos

### DIFF
--- a/gestor-frontend/src/components/Organizacion.jsx
+++ b/gestor-frontend/src/components/Organizacion.jsx
@@ -31,7 +31,7 @@ export default function Organizacion() {
           <h1 className="text-4xl font-bold bg-gradient-to-r from-blue-600 to-purple-500 bg-clip-text text-transparent">
             Organización
           </h1>
-          <p className="text-gray-600 mt-2">Resumen de empresas, países y antigüedad.</p>
+          <p className="text-gray-600 mt-2">Resumen de empresas, países y antigüedad de trabajadores activos.</p>
         </div>
 
         {error && (


### PR DESCRIPTION
## Summary
- Restringe `getOrganizationInfo` para que solo considere trabajadores activos en estadísticas de organización.
- Actualiza la vista de organización para indicar que los datos se refieren a trabajadores activos.

## Testing
- `npm test` (backend) *(fails: Error: no test specified)*
- `npm test` (frontend) *(fails: Missing script: "test")*
- `npm run lint` *(fails: 16 problems (14 errors, 2 warnings))*

------
https://chatgpt.com/codex/tasks/task_e_68a6d6a51f9c832b93e8d62dfec41458