### PR TITLE
fix: preserve fractional negative hours

### DIFF
--- a/gestor-backend/models/horario.model.js
+++ b/gestor-backend/models/horario.model.js
@@ -35,7 +35,7 @@ module.exports = (sequelize, DataTypes) => {
       defaultValue: false,
     },
     horanegativa: {
-      type: DataTypes.INTEGER,
+      type: DataTypes.DECIMAL(5, 2),
       defaultValue: 0,
     },
     dianegativo: {


### PR DESCRIPTION
## Summary
- allow storing decimal negative hours without rounding

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68a6d915f2b8832bbea1a0dbeb4a194b