### PR TITLE
fix: handle negative hour formatting

### DIFF
--- a/gestor-frontend/src/components/HorarioModal.jsx
+++ b/gestor-frontend/src/components/HorarioModal.jsx
@@ -31,18 +31,26 @@ export default function HorarioModal({
   const parseHoursInput = (val) => {
     if (!val) return 0;
     const normalized = val.replace(',', '.');
-    const [hPart, mPart = '0'] = normalized.split('.');
+    const sign = normalized.trim().startsWith('-') ? -1 : 1;
+    const unsigned = normalized.replace('-', '');
+    const [hPart, mPart = '0'] = unsigned.split('.');
     const hours = parseInt(hPart, 10) || 0;
     let minutes = parseInt(mPart, 10) || 0;
     if (mPart.length === 1) minutes *= 6;
     if (minutes > 59) minutes = 59;
-    return hours + minutes / 60;
+    return sign * (hours + minutes / 60);
   };
 
   const formatHoursInput = (val) => {
-    const hours = Math.floor(val);
-    const minutes = Math.round((val - hours) * 60);
-    return `${hours},${minutes.toString().padStart(2, '0')}`;
+    const sign = val < 0 ? '-' : '';
+    const absVal = Math.abs(val);
+    let hours = Math.floor(absVal);
+    let minutes = Math.round((absVal - hours) * 60);
+    if (minutes === 60) {
+      hours += 1;
+      minutes = 0;
+    }
+    return `${sign}${hours},${minutes.toString().padStart(2, '0')}`;
   };
   
   useEffect(() => {
@@ -162,7 +170,7 @@ export default function HorarioModal({
           </p>
 
           <div className="space-y-2">
-            {intervals.map((intv, i) => (
+            {intervals.map((intv) => (
               <div key={intv.id} className="flex gap-2 items-center">
                 <input
                   type="time"

--- a/gestor-frontend/src/components/ScheduleManager.jsx
+++ b/gestor-frontend/src/components/ScheduleManager.jsx
@@ -13,6 +13,7 @@ import {
   exportAllSchedulesToExcel,
   exportYearScheduleToExcel
 } from '@/utils/exportExcel';
+import { formatHoursToHM } from '@/utils/utils';
 
 export default function ScheduleManager() {
   const [trabajadores, setTrabajadores] = useState([]);
@@ -179,12 +180,6 @@ export default function ScheduleManager() {
       setScheduleData(res.data);
     });
   }, [selectedTrabajadorId, currentDate]);
-
-  const formatHoursToHM = (total) => {
-    const hours = Math.floor(total);
-    const minutes = Math.round((total - hours) * 60);
-    return `${hours.toString().padStart(2, '0')}:${minutes.toString().padStart(2, '0')}h`;
-  };
 
   const groupedData = agruparHorarios(scheduleData);
 

--- a/gestor-frontend/src/utils/exportExcel.js
+++ b/gestor-frontend/src/utils/exportExcel.js
@@ -69,9 +69,15 @@ function toHM(num) {
   if (num === 0 || num === undefined || num === null) {
     return '';
   }
-  const hours = Math.floor(num);
-  const minutes = Math.round((num - hours) * 60);
-  return `${hours.toString().padStart(2, '0')}:${minutes.toString().padStart(2, '0')}`;
+  const sign = num < 0 ? '-' : '';
+  const absVal = Math.abs(num);
+  let hours = Math.floor(absVal);
+  let minutes = Math.round((absVal - hours) * 60);
+  if (minutes === 60) {
+    hours += 1;
+    minutes = 0;
+  }
+  return `${sign}${hours.toString().padStart(2, '0')}:${minutes.toString().padStart(2, '0')}`;
 }
 
 export async function addScheduleWorksheet(

--- a/gestor-frontend/src/utils/utils.js
+++ b/gestor-frontend/src/utils/utils.js
@@ -27,9 +27,15 @@ export function formatHours(value) {
 
 
 export const formatHoursToHM = (total) => {
-  const hours = Math.floor(total);
-  const minutes = Math.round((total - hours) * 60);
-  return `${hours.toString().padStart(2, '0')}:${minutes.toString().padStart(2, '0')}h`;
+  const sign = total < 0 ? '-' : '';
+  const absTotal = Math.abs(total);
+  let hours = Math.floor(absTotal);
+  let minutes = Math.round((absTotal - hours) * 60);
+  if (minutes === 60) {
+    hours += 1;
+    minutes = 0;
+  }
+  return `${sign}${hours.toString().padStart(2, '0')}:${minutes.toString().padStart(2, '0')}h`;
 };
 
 export function formatCurrency(value) {


### PR DESCRIPTION
## Summary
- allow negative hour inputs by parsing and formatting with sign support
- prevent negative-time rounding in display, calendar, and Excel export

## Testing
- `npm run lint` *(fails: 'module' is not defined etc)*
- `npx eslint src/components/HorarioModal.jsx src/components/ScheduleManager.jsx src/utils/utils.js src/utils/exportExcel.js`


------
https://chatgpt.com/codex/tasks/task_e_68a6daa5d4d4832b8877d1e99676cfa9