### PR TITLE
Limit notifications to active workers

### DIFF
--- a/gestor-frontend/src/components/Header.jsx
+++ b/gestor-frontend/src/components/Header.jsx
@@ -21,6 +21,13 @@ export default function Header() {
   const [notifications, setNotifications] = useState([]);
   const [showNotifications, setShowNotifications] = useState(false);
 
+  const isActivo = (trabajador) => {
+    const today = new Date();
+    const fechaAlta = new Date(trabajador.fecha_alta);
+    const fechaBaja = trabajador.fecha_baja ? new Date(trabajador.fecha_baja) : null;
+    return fechaAlta <= today && (!fechaBaja || fechaBaja >= today);
+  };
+
   const handleResize = () => setIsMobile(window.innerWidth < 768);
 
   useEffect(() => {
@@ -38,7 +45,7 @@ export default function Header() {
         );
         const today = new Date();
         const upcoming = [];
-        res.data.forEach((w) => {
+        res.data.filter(isActivo).forEach((w) => {
           if (w.fecha_baja) {
             const diff = (new Date(w.fecha_baja) - today) / (1000 * 60 * 60 * 24);
             if (diff >= 0 && diff <= 7) {


### PR DESCRIPTION
## Summary
- only generate UI notifications for active employees

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: no-unused-vars and other errors)


------
https://chatgpt.com/codex/tasks/task_e_68a6e5c92ad8832bb721d3c2fb2d5efe