### PR TITLE
feat: enforce 24-hour schedule inputs

### DIFF
--- a/gestor-frontend/src/components/HorarioModal.jsx
+++ b/gestor-frontend/src/components/HorarioModal.jsx
@@ -174,6 +174,7 @@ export default function HorarioModal({
               <div key={intv.id} className="flex gap-2 items-center">
                 <input
                   type="time"
+                  lang="es"
                   value={intv.hora_inicio}
                   onChange={(e) => handleChange(intv.id, 'hora_inicio', e.target.value)}
                   className="border p-1 rounded w-full text-black"
@@ -181,6 +182,7 @@ export default function HorarioModal({
                 <span>-</span>
                 <input
                   type="time"
+                  lang="es"
                   value={intv.hora_fin}
                   onChange={(e) => handleChange(intv.id, 'hora_fin', e.target.value)}
                   className="border p-1 rounded w-full text-black"

--- a/gestor-frontend/src/components/HorasResumen.jsx
+++ b/gestor-frontend/src/components/HorasResumen.jsx
@@ -38,14 +38,14 @@ function calcularTipoHoras(intervals, dateKey, isFestivo, isVacaciones, isBaja) 
       return; // Todo el intervalo es festivo
     }
 
-    // 360 minutos = 6:00 AM
+    // 360 minutos = 06:00
     if (start < 360) {
       const nocturnaFin = Math.min(end, 360); // límite superior hasta las 6:00
       nocturnas += (nocturnaFin - start) / 60;
       total -= (nocturnaFin - start) / 60;
     }
 
-    // 1320 minutos = 22:00 PM
+    // 1320 minutos = 22:00
     if (end > 1320) {
       const nocturnaInicio = Math.max(start, 1320); // límite inferior desde las 22:00
       nocturnas += (end - nocturnaInicio) / 60;


### PR DESCRIPTION
## Summary
- use Spanish locale on time inputs to show 24-hour clock
- remove AM/PM mentions from hour summary comments

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 13 errors, 2 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68a81b6005dc832ba4d55c8cd3446d3e