### PR TITLE
Improve mobile responsiveness for frontend pages

### DIFF
--- a/gestor-frontend/index.html
+++ b/gestor-frontend/index.html
@@ -21,7 +21,7 @@
       }
     </script>
   </head>
-  <body class="bg-slate-900 text-white">
+  <body class="bg-slate-900 text-white overflow-x-hidden">
     <div id="root"></div>
     <script type="module" src="/src/main.jsx"></script>
   </body>

--- a/gestor-frontend/src/components/Header.jsx
+++ b/gestor-frontend/src/components/Header.jsx
@@ -1,6 +1,6 @@
 // src/components/Header.jsx
 import { useState, useEffect } from 'react';
-import { NavLink, useNavigate, useLocation } from 'react-router-dom';
+import { NavLink, useNavigate } from 'react-router-dom';
 import {
   LogOut,
   CalendarClock,
@@ -10,14 +10,13 @@ import {
   Menu,
   Bell
 } from 'lucide-react';
+// eslint-disable-next-line no-unused-vars
 import { motion, AnimatePresence } from 'framer-motion';
 import axios from 'axios';
 
 export default function Header() {
   const navigate = useNavigate();
-  const location = useLocation();
   const [menuOpen, setMenuOpen] = useState(false);
-  const [isMobile, setIsMobile] = useState(window.innerWidth < 768);
   const [notifications, setNotifications] = useState([]);
   const [showNotifications, setShowNotifications] = useState(false);
 
@@ -28,12 +27,6 @@ export default function Header() {
     return fechaAlta <= today && (!fechaBaja || fechaBaja >= today);
   };
 
-  const handleResize = () => setIsMobile(window.innerWidth < 768);
-
-  useEffect(() => {
-    window.addEventListener('resize', handleResize);
-    return () => window.removeEventListener('resize', handleResize);
-  }, []);
 
   useEffect(() => {
     const fetchNotifications = async () => {

--- a/gestor-frontend/src/components/HorasResumen.jsx
+++ b/gestor-frontend/src/components/HorasResumen.jsx
@@ -1,10 +1,9 @@
 // src/components/HorasResumen.jsx
 import React from 'react';
-import { motion } from 'framer-motion';
 import { Clock, Calendar, Download } from 'lucide-react';
 import { getYear, getMonth, getDay, parseISO, format } from 'date-fns';
 import { es } from 'date-fns/locale';
-import { calculateTotalHoursFromIntervals, formatHoursToHM } from '../utils/utils';
+import { formatHoursToHM } from '../utils/utils';
 
 
 function calcularTipoHoras(intervals, dateKey, isFestivo, isVacaciones, isBaja) {

--- a/gestor-frontend/src/components/HorasResumenAnual.jsx
+++ b/gestor-frontend/src/components/HorasResumenAnual.jsx
@@ -1,6 +1,5 @@
 // src/components/HorasResumenAnual.jsx
 import React from 'react';
-import { motion } from 'framer-motion';
 import { Clock, Download } from 'lucide-react';
 import { getYear, getDay, parseISO, format } from 'date-fns';
 import { formatHoursToHM } from '../utils/utils';

--- a/gestor-frontend/src/components/Organizacion.jsx
+++ b/gestor-frontend/src/components/Organizacion.jsx
@@ -26,16 +26,16 @@ export default function Organizacion() {
   return (
     <>
       <Header />
-      <div className="min-h-screen bg-slate-100 p-6">
-        <div className="max-w-5xl mx-auto mb-6 text-center">
-          <h1 className="text-4xl font-bold bg-gradient-to-r from-blue-600 to-purple-500 bg-clip-text text-transparent">
+      <div className="min-h-screen bg-slate-100 p-4 sm:p-6">
+        <div className="w-full max-w-5xl mx-auto mb-4 sm:mb-6 text-center px-4">
+          <h1 className="text-2xl sm:text-3xl md:text-4xl font-bold bg-gradient-to-r from-blue-600 to-purple-500 bg-clip-text text-transparent">
             Organización
           </h1>
           <p className="text-gray-600 mt-2">Resumen de empresas, países y antigüedad de trabajadores activos.</p>
         </div>
 
         {error && (
-          <div className="max-w-5xl mx-auto mb-4 bg-red-100 text-red-700 p-4 rounded shadow">
+          <div className="w-full max-w-5xl mx-auto mb-4 bg-red-100 text-red-700 p-4 rounded shadow">
             {error}
           </div>
         )}
@@ -44,8 +44,8 @@ export default function Organizacion() {
           <p className="text-center text-gray-600 mt-12">Cargando datos...</p>
         ) : (
           <>
-            <div className="grid grid-cols-1 md:grid-cols-2 gap-6 max-w-5xl mx-auto">
-              <div className="bg-white text-gray-800 p-6 rounded-xl shadow">
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-4 sm:gap-6 w-full max-w-5xl mx-auto px-4">
+              <div className="bg-white text-gray-800 p-4 sm:p-6 rounded-xl shadow">
                 <h2 className="text-lg font-semibold mb-4">Trabajadores por empresa</h2>
                 <ul className="space-y-2">
                   {stats.porEmpresa.map((e) => (
@@ -57,7 +57,7 @@ export default function Organizacion() {
                 </ul>
               </div>
 
-              <div className="bg-white text-gray-800 p-6 rounded-xl shadow">
+              <div className="bg-white text-gray-800 p-4 sm:p-6 rounded-xl shadow">
                 <h2 className="text-lg font-semibold mb-4">Trabajadores por país</h2>
                 <ul className="space-y-2">
                   {stats.porPais.map((p) => (
@@ -70,7 +70,7 @@ export default function Organizacion() {
               </div>
             </div>
 
-            <div className="max-w-5xl mx-auto mt-6 bg-white text-gray-800 p-6 rounded-xl shadow">
+            <div className="w-full max-w-5xl mx-auto mt-6 bg-white text-gray-800 p-4 sm:p-6 rounded-xl shadow">
               <h2 className="text-lg font-semibold mb-4">Trabajadores con más antigüedad</h2>
               <ul className="space-y-2">
                 {stats.veteranos.map((v) => (
@@ -82,8 +82,8 @@ export default function Organizacion() {
               </ul>
             </div>
 
-            <div className="grid grid-cols-1 md:grid-cols-2 gap-6 max-w-5xl mx-auto mt-6">
-              <div className="bg-white text-gray-800 p-6 rounded-xl shadow">
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-4 sm:gap-6 w-full max-w-5xl mx-auto mt-6 px-4">
+              <div className="bg-white text-gray-800 p-4 sm:p-6 rounded-xl shadow">
                 <h2 className="text-lg font-semibold mb-4">Nuevas incorporaciones</h2>
                 <ul className="space-y-2">
                   <li className="flex justify-between">
@@ -97,7 +97,7 @@ export default function Organizacion() {
                 </ul>
               </div>
 
-              <div className="bg-white text-gray-800 p-6 rounded-xl shadow">
+              <div className="bg-white text-gray-800 p-4 sm:p-6 rounded-xl shadow">
                 <h2 className="text-lg font-semibold mb-4">Distribución por contrato</h2>
                 <ul className="space-y-2">
                   {stats.porContrato.map((c) => (
@@ -110,8 +110,8 @@ export default function Organizacion() {
               </div>
             </div>
 
-            <div className="grid grid-cols-1 md:grid-cols-2 gap-6 max-w-5xl mx-auto mt-6">
-              <div className="bg-white text-gray-800 p-6 rounded-xl shadow">
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-4 sm:gap-6 w-full max-w-5xl mx-auto mt-6 px-4">
+              <div className="bg-white text-gray-800 p-4 sm:p-6 rounded-xl shadow">
                 <h2 className="text-lg font-semibold mb-4">Distribución por rol</h2>
                 <ul className="space-y-2">
                   {stats.porRol.map((r) => (
@@ -123,7 +123,7 @@ export default function Organizacion() {
                 </ul>
               </div>
 
-              <div className="bg-white text-gray-800 p-6 rounded-xl shadow">
+              <div className="bg-white text-gray-800 p-4 sm:p-6 rounded-xl shadow">
                 <h2 className="text-lg font-semibold mb-4">Promedios y extras</h2>
                 <ul className="space-y-2">
                   <li className="flex justify-between">

--- a/gestor-frontend/src/components/Proyecciones.jsx
+++ b/gestor-frontend/src/components/Proyecciones.jsx
@@ -36,23 +36,23 @@ export default function Proyecciones() {
   return (
     <>
       <Header />
-      <div className="min-h-screen bg-slate-100 p-6">
-        <div className="max-w-5xl mx-auto mb-6 text-center">
-          <h1 className="text-4xl font-bold bg-gradient-to-r from-blue-600 to-purple-500 bg-clip-text text-transparent">
+      <div className="min-h-screen bg-slate-100 p-4 sm:p-6">
+        <div className="w-full max-w-5xl mx-auto mb-4 sm:mb-6 text-center px-4">
+          <h1 className="text-2xl sm:text-3xl md:text-4xl font-bold bg-gradient-to-r from-blue-600 to-purple-500 bg-clip-text text-transparent">
             Proyecciones y Estadísticas
           </h1>
           <p className="text-gray-600 mt-2">Visualiza el estado económico de tu plantilla.</p>
         </div>
 
         {error && (
-          <div className="max-w-5xl mx-auto mb-4 bg-red-100 text-red-700 p-4 rounded shadow">
+          <div className="w-full max-w-5xl mx-auto mb-4 bg-red-100 text-red-700 p-4 rounded shadow">
             {error}
           </div>
         )}
 
         {stats ? (
           <>
-            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 max-w-5xl mx-auto mb-10">
+            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4 sm:gap-6 w-full max-w-5xl mx-auto mb-10 px-4">
               <StatCard title="Trabajadores totales" value={stats.totalTrabajadores} />
               <StatCard title="Activos" value={stats.trabajadoresActivos} />
               <StatCard title="Inactivos" value={stats.trabajadoresInactivos} />
@@ -61,8 +61,8 @@ export default function Proyecciones() {
               <StatCard title="Salario bruto promedio" value={`€ ${formatCurrency(stats.salarioBrutoPromedio)}`} />
             </div>
 
-            <div className="max-w-5xl mx-auto bg-white p-6 rounded-xl shadow-xl">
-              <h2 className="text-xl font-semibold mb-4 text-gray-700">Gráfico comparativo</h2>
+            <div className="w-full max-w-5xl mx-auto bg-white p-4 sm:p-6 rounded-xl shadow-xl">
+              <h2 className="text-lg sm:text-xl font-semibold mb-4 text-gray-700">Gráfico comparativo</h2>
               <div className="w-full h-80">
                 <ResponsiveContainer>
                   <BarChart data={chartData}>
@@ -86,7 +86,7 @@ export default function Proyecciones() {
 
 function StatCard({ title, value }) {
   return (
-    <div className="bg-white p-6 rounded-xl shadow hover:shadow-md transition text-center">
+    <div className="bg-white p-4 sm:p-6 rounded-xl shadow hover:shadow-md transition text-center">
       <p className="text-gray-500 text-sm">{title}</p>
       <p className="text-2xl font-bold text-blue-700 mt-2">{value}</p>
     </div>

--- a/gestor-frontend/src/components/ScheduleManager.jsx
+++ b/gestor-frontend/src/components/ScheduleManager.jsx
@@ -276,9 +276,9 @@ export default function ScheduleManager() {
   return (
     <>
       <Header />
-      <div className="min-h-screen bg-slate-100 p-6">
-        <div className="max-w-5xl mx-auto mb-6 text-center">
-          <h1 className="text-4xl font-bold bg-gradient-to-r from-purple-600 to-pink-500 bg-clip-text text-transparent">
+      <div className="min-h-screen bg-slate-100 p-4 sm:p-6">
+        <div className="w-full max-w-5xl mx-auto mb-4 sm:mb-6 text-center px-4">
+          <h1 className="text-2xl sm:text-3xl md:text-4xl font-bold bg-gradient-to-r from-purple-600 to-pink-500 bg-clip-text text-transparent">
             Gestor Avanzado de Horarios
           </h1>
           <p className="text-gray-600 mt-2">
@@ -286,7 +286,7 @@ export default function ScheduleManager() {
           </p>
         </div>
 
-        <div className="max-w-5xl mx-auto mb-4 flex flex-col sm:flex-row justify-between items-center gap-4">
+        <div className="w-full max-w-5xl mx-auto mb-4 flex flex-col sm:flex-row justify-between items-center gap-4 px-4">
           <div className="w-full sm:w-auto">
             <label className="block text-sm font-medium text-gray-700 mb-1">Seleccionar Trabajador:</label>
             <WorkerAutocomplete
@@ -311,7 +311,7 @@ export default function ScheduleManager() {
           </button>
         </div>
 
-        <div className="bg-white rounded-xl shadow-xl max-w-5xl mx-auto p-6">
+        <div className="w-full bg-white rounded-xl shadow-xl max-w-5xl mx-auto p-4 sm:p-6">
           <div className="flex items-center justify-between mb-6">
             <button
               onClick={() => setCurrentDate(new Date(currentDate.setMonth(currentDate.getMonth() - 1)))}
@@ -343,7 +343,7 @@ export default function ScheduleManager() {
           </div>
         </div>
 
-        <div className="max-w-5xl mx-auto">
+        <div className="w-full max-w-5xl mx-auto px-4">
           <HoursSummary
             currentDate={currentDate}
             scheduleData={agruparHorarios(scheduleData)}

--- a/gestor-frontend/src/components/Trabajador.jsx
+++ b/gestor-frontend/src/components/Trabajador.jsx
@@ -6,6 +6,7 @@ import {
   Calendar, Euro, ClipboardSignature, Edit3, HardHat,
   Clock, Users, Tag, Banknote, Shield
 } from 'lucide-react';
+// eslint-disable-next-line no-unused-vars
 import { motion, AnimatePresence } from 'framer-motion';
 import Header from '@/components/Header';
 import AddWorkerModal from '@/components/forms/AddWorkerModal';
@@ -61,11 +62,6 @@ export default function Trabajador() {
       if (valorA > valorB) return 1;
       return 0;
     });
-
-  const paginatedTrabajadores = filteredTrabajadores.slice(
-    (currentPage - 1) * workersPerPage,
-    currentPage * workersPerPage
-  );
 
   const indexOfLastWorker = currentPage * workersPerPage;
   const indexOfFirstWorker = indexOfLastWorker - workersPerPage;
@@ -166,9 +162,9 @@ const handleBaja = async (id) => {
   return (
     <>
     <Header />
-    <div className="min-h-screen bg-slate-100 p-6">
-      <div className="flex justify-between items-center mb-6">
-        <div className="flex flex-col md:flex-row gap-4 mb-6">
+    <div className="min-h-screen bg-slate-100 p-4 sm:p-6">
+      <div className="flex flex-col md:flex-row justify-between md:items-center mb-6 gap-4">
+        <div className="flex flex-col md:flex-row gap-4 w-full md:w-auto">
           <input
             type="text"
             placeholder={`Buscar por ${filterOptions.find(o => o.value === filterBy)?.label.toLowerCase()}...`}
@@ -190,7 +186,7 @@ const handleBaja = async (id) => {
 
         <button
           onClick={() => setShowAddModal(true)}
-          className="bg-green-600 hover:bg-green-700 text-white px-4 py-2 rounded"
+          className="bg-green-600 hover:bg-green-700 text-white px-4 py-2 rounded w-full md:w-auto"
         >
           Añadir Trabajador
         </button>
@@ -199,11 +195,11 @@ const handleBaja = async (id) => {
 
       {error && <p className="text-red-600 mb-4">{error}</p>}
 
-      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4 sm:gap-6">
       {currentTrabajadores.map((t) => (
           <div
             key={t.id}
-            className={`rounded-xl p-6 space-y-3 text-sm shadow transition-all duration-300 ${
+            className={`rounded-xl p-4 sm:p-6 space-y-3 text-sm shadow transition-all duration-300 ${
               isActivo(t) ? 'bg-white border border-gray-200' : 'bg-red-50 border border-red-400'
             }`}
           >

--- a/gestor-frontend/src/components/forms/AddWorkerModal.jsx
+++ b/gestor-frontend/src/components/forms/AddWorkerModal.jsx
@@ -1,6 +1,6 @@
 // src/components/forms/AddWorkerModal.jsx
 import React, { useState } from 'react';
-import { motion, AnimatePresence } from 'framer-motion';
+import { AnimatePresence } from 'framer-motion';
 import { parseCurrency, formatCurrency } from '@/utils/utils';
 
 export default function AddWorkerModal({ open, onClose, onWorkerAdded }) {

--- a/gestor-frontend/src/components/forms/EditWorkerModal.jsx
+++ b/gestor-frontend/src/components/forms/EditWorkerModal.jsx
@@ -1,6 +1,6 @@
 // src/components/forms/EditWorkerModal.jsx
 import React, { useState, useEffect } from 'react';
-import { motion, AnimatePresence } from 'framer-motion';
+import { AnimatePresence } from 'framer-motion';
 import { parseCurrency, formatCurrency } from '@/utils/utils';
 
 export default function EditWorkerModal({ open, onClose, onWorkerUpdated, initialData }) {

--- a/gestor-frontend/tailwind.config.js
+++ b/gestor-frontend/tailwind.config.js
@@ -1,3 +1,5 @@
+/* eslint-env node */
+/* eslint-disable no-undef */
 /** @type {import('tailwindcss').Config} */
 module.exports = {
 	darkMode: ['class'],

--- a/gestor-frontend/vite.config.js
+++ b/gestor-frontend/vite.config.js
@@ -1,3 +1,5 @@
+/* eslint-env node */
+/* eslint-disable no-undef */
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 import path from 'path'


### PR DESCRIPTION
## Summary
- Optimize layouts for small screens across ScheduleManager, Organizacion, Proyecciones, and Trabajador pages
- Prevent horizontal scrolling by hiding overflow on the body element
- Clean up unused imports and configure tooling to support Node-based config files

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a81b789460832bbb84b7d4987d080d