### PR TITLE
feat: expand organization panel with collapsible details

### DIFF
--- a/gestor-frontend/src/components/Organizacion.jsx
+++ b/gestor-frontend/src/components/Organizacion.jsx
@@ -1,10 +1,20 @@
 import { useEffect, useState } from 'react';
 import axios from 'axios';
+import { ChevronDown } from 'lucide-react';
 import Header from '@/components/Header';
+import { isActivo } from '@/components/Trabajador';
 
 export default function Organizacion() {
   const [stats, setStats] = useState(null);
   const [error, setError] = useState('');
+  const [openEmpresas, setOpenEmpresas] = useState({});
+  const [openPaises, setOpenPaises] = useState({});
+  const [openContratos, setOpenContratos] = useState({});
+  const [openRoles, setOpenRoles] = useState({});
+
+  const toggle = (setter, key) => {
+    setter(prev => ({ ...prev, [key]: !prev[key] }));
+  };
 
   useEffect(() => {
     const fetchStats = async () => {
@@ -48,24 +58,90 @@ export default function Organizacion() {
               <div className="bg-white text-gray-800 p-4 sm:p-6 rounded-xl shadow">
                 <h2 className="text-lg font-semibold mb-4">Trabajadores por empresa</h2>
                 <ul className="space-y-2">
-                  {stats.porEmpresa.map((e) => (
-                    <li key={e.empresa} className="flex justify-between">
-                      <span>{e.empresa || 'Sin especificar'}</span>
-                      <span className="font-bold">{e.count}</span>
-                    </li>
-                  ))}
+                  {stats.porEmpresa.map((e) => {
+                    const key = e.empresa || 'Sin especificar';
+                    return (
+                      <li key={key} className="">
+                        <button
+                          onClick={() => toggle(setOpenEmpresas, key)}
+                          className="w-full flex justify-between items-center"
+                        >
+                          <span>{key}</span>
+                          <div className="flex items-center gap-2">
+                            <span className="font-bold">{e.count}</span>
+                            <ChevronDown
+                              className={`w-4 h-4 transition-transform ${
+                                openEmpresas[key] ? 'rotate-180' : ''
+                              }`}
+                            />
+                          </div>
+                        </button>
+                        {openEmpresas[key] && (
+                          <ul className="mt-2 ml-4 space-y-1">
+                            {e.workers.map(w => (
+                              <li key={w.id} className="flex justify-between text-sm">
+                                <span>{w.nombre}</span>
+                                <span
+                                  className={`text-xs font-bold px-2 py-0.5 rounded-full ${
+                                    isActivo(w)
+                                      ? 'bg-green-100 text-green-700'
+                                      : 'bg-red-100 text-red-700'
+                                  }`}
+                                >
+                                  {isActivo(w) ? 'Activo' : 'Inactivo'}
+                                </span>
+                              </li>
+                            ))}
+                          </ul>
+                        )}
+                      </li>
+                    );
+                  })}
                 </ul>
               </div>
 
               <div className="bg-white text-gray-800 p-4 sm:p-6 rounded-xl shadow">
                 <h2 className="text-lg font-semibold mb-4">Trabajadores por país</h2>
                 <ul className="space-y-2">
-                  {stats.porPais.map((p) => (
-                    <li key={p.pais} className="flex justify-between">
-                      <span>{p.pais || 'Sin especificar'}</span>
-                      <span className="font-bold">{p.count}</span>
-                    </li>
-                  ))}
+                  {stats.porPais.map((p) => {
+                    const key = p.pais || 'Sin especificar';
+                    return (
+                      <li key={key}>
+                        <button
+                          onClick={() => toggle(setOpenPaises, key)}
+                          className="w-full flex justify-between items-center"
+                        >
+                          <span>{key}</span>
+                          <div className="flex items-center gap-2">
+                            <span className="font-bold">{p.count}</span>
+                            <ChevronDown
+                              className={`w-4 h-4 transition-transform ${
+                                openPaises[key] ? 'rotate-180' : ''
+                              }`}
+                            />
+                          </div>
+                        </button>
+                        {openPaises[key] && (
+                          <ul className="mt-2 ml-4 space-y-1">
+                            {p.workers.map(w => (
+                              <li key={w.id} className="flex justify-between text-sm">
+                                <span>{w.nombre}</span>
+                                <span
+                                  className={`text-xs font-bold px-2 py-0.5 rounded-full ${
+                                    isActivo(w)
+                                      ? 'bg-green-100 text-green-700'
+                                      : 'bg-red-100 text-red-700'
+                                  }`}
+                                >
+                                  {isActivo(w) ? 'Activo' : 'Inactivo'}
+                                </span>
+                              </li>
+                            ))}
+                          </ul>
+                        )}
+                      </li>
+                    );
+                  })}
                 </ul>
               </div>
             </div>
@@ -74,9 +150,20 @@ export default function Organizacion() {
               <h2 className="text-lg font-semibold mb-4">Trabajadores con más antigüedad</h2>
               <ul className="space-y-2">
                 {stats.veteranos.map((v) => (
-                  <li key={v.id} className="flex justify-between">
+                  <li key={v.id} className="flex justify-between items-center">
                     <span>{v.nombre}</span>
-                    <span className="font-bold">{v.antiguedad} años</span>
+                    <div className="flex items-center gap-2">
+                      <span
+                        className={`text-xs font-bold px-2 py-0.5 rounded-full ${
+                          isActivo(v)
+                            ? 'bg-green-100 text-green-700'
+                            : 'bg-red-100 text-red-700'
+                        }`}
+                      >
+                        {isActivo(v) ? 'Activo' : 'Inactivo'}
+                      </span>
+                      <span className="font-bold">{v.antiguedad} años</span>
+                    </div>
                   </li>
                 ))}
               </ul>
@@ -100,12 +187,45 @@ export default function Organizacion() {
               <div className="bg-white text-gray-800 p-4 sm:p-6 rounded-xl shadow">
                 <h2 className="text-lg font-semibold mb-4">Distribución por contrato</h2>
                 <ul className="space-y-2">
-                  {stats.porContrato.map((c) => (
-                    <li key={c.tipo_trabajador} className="flex justify-between">
-                      <span>{c.tipo_trabajador || 'Sin especificar'}</span>
-                      <span className="font-bold">{c.count}</span>
-                    </li>
-                  ))}
+                  {stats.porContrato.map((c) => {
+                    const key = c.tipo_trabajador || 'Sin especificar';
+                    return (
+                      <li key={key}>
+                        <button
+                          onClick={() => toggle(setOpenContratos, key)}
+                          className="w-full flex justify-between items-center"
+                        >
+                          <span>{key}</span>
+                          <div className="flex items-center gap-2">
+                            <span className="font-bold">{c.count}</span>
+                            <ChevronDown
+                              className={`w-4 h-4 transition-transform ${
+                                openContratos[key] ? 'rotate-180' : ''
+                              }`}
+                            />
+                          </div>
+                        </button>
+                        {openContratos[key] && (
+                          <ul className="mt-2 ml-4 space-y-1">
+                            {c.workers.map(w => (
+                              <li key={w.id} className="flex justify-between text-sm">
+                                <span>{w.nombre}</span>
+                                <span
+                                  className={`text-xs font-bold px-2 py-0.5 rounded-full ${
+                                    isActivo(w)
+                                      ? 'bg-green-100 text-green-700'
+                                      : 'bg-red-100 text-red-700'
+                                  }`}
+                                >
+                                  {isActivo(w) ? 'Activo' : 'Inactivo'}
+                                </span>
+                              </li>
+                            ))}
+                          </ul>
+                        )}
+                      </li>
+                    );
+                  })}
                 </ul>
               </div>
             </div>
@@ -114,12 +234,45 @@ export default function Organizacion() {
               <div className="bg-white text-gray-800 p-4 sm:p-6 rounded-xl shadow">
                 <h2 className="text-lg font-semibold mb-4">Distribución por rol</h2>
                 <ul className="space-y-2">
-                  {stats.porRol.map((r) => (
-                    <li key={r.categoria} className="flex justify-between">
-                      <span>{r.categoria || 'Sin especificar'}</span>
-                      <span className="font-bold">{r.count}</span>
-                    </li>
-                  ))}
+                  {stats.porRol.map((r) => {
+                    const key = r.categoria || 'Sin especificar';
+                    return (
+                      <li key={key}>
+                        <button
+                          onClick={() => toggle(setOpenRoles, key)}
+                          className="w-full flex justify-between items-center"
+                        >
+                          <span>{key}</span>
+                          <div className="flex items-center gap-2">
+                            <span className="font-bold">{r.count}</span>
+                            <ChevronDown
+                              className={`w-4 h-4 transition-transform ${
+                                openRoles[key] ? 'rotate-180' : ''
+                              }`}
+                            />
+                          </div>
+                        </button>
+                        {openRoles[key] && (
+                          <ul className="mt-2 ml-4 space-y-1">
+                            {r.workers.map(w => (
+                              <li key={w.id} className="flex justify-between text-sm">
+                                <span>{w.nombre}</span>
+                                <span
+                                  className={`text-xs font-bold px-2 py-0.5 rounded-full ${
+                                    isActivo(w)
+                                      ? 'bg-green-100 text-green-700'
+                                      : 'bg-red-100 text-red-700'
+                                  }`}
+                                >
+                                  {isActivo(w) ? 'Activo' : 'Inactivo'}
+                                </span>
+                              </li>
+                            ))}
+                          </ul>
+                        )}
+                      </li>
+                    );
+                  })}
                 </ul>
               </div>
 


### PR DESCRIPTION
## Summary
- include worker details in organization stats endpoint
- add collapsible lists showing worker activity status in organization panel

## Testing
- `npm run lint`
- `npm test` (fails: Error: no test specified)


------
https://chatgpt.com/codex/tasks/task_e_68aec9582d3c832bb5a5c00a0aaeca05