### PR TITLE
Show gross and net salary distribution

### DIFF
--- a/gestor-frontend/src/components/Proyecciones.jsx
+++ b/gestor-frontend/src/components/Proyecciones.jsx
@@ -38,7 +38,8 @@ export default function Proyecciones() {
         const mappedWorkers = workersRes.data.map((w) => ({
           id: w.id,
           name: w.nombre,
-          salary: w.salario_bruto,
+          bruto: Number(w.salario_bruto),
+          neto: Number(w.salario_neto),
           active: isActivo(w)
         }));
         setWorkers(mappedWorkers);


### PR DESCRIPTION
## Summary
- include workers' gross and net salaries when loading salary distribution
- chart renders separate gross and net salary distributions with legend and detailed tooltips

## Testing
- `npm test` (gestor-frontend) *(fails: Missing script "test")*
- `npm run lint` (gestor-frontend)
- `npm test` (gestor-backend) *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68aeddc97784832ba0c00e924b09705f