### PR TITLE
Separate salary chart and table in projections

### DIFF
--- a/gestor-frontend/src/components/Proyecciones.jsx
+++ b/gestor-frontend/src/components/Proyecciones.jsx
@@ -12,6 +12,7 @@ import {
 } from 'recharts';
 import { formatCurrency } from '@/utils/utils';
 import SalaryLineChart from '@/components/SalaryLineChart';
+import SalaryTable from '@/components/SalaryTable';
 
 function isActivo(trabajador) {
   const today = new Date();
@@ -122,6 +123,11 @@ export default function Proyecciones() {
             <div className="w-full max-w-5xl mx-auto bg-white p-4 sm:p-6 rounded-xl shadow-xl mt-6">
               <h2 className="text-lg sm:text-xl font-semibold mb-4 text-gray-700">Distribución de salarios</h2>
               <SalaryLineChart workers={workers} />
+            </div>
+
+            <div className="w-full max-w-5xl mx-auto bg-white p-4 sm:p-6 rounded-xl shadow-xl mt-6">
+              <h2 className="text-lg sm:text-xl font-semibold mb-4 text-gray-700">Salarios por trabajador</h2>
+              <SalaryTable workers={workers} />
             </div>
           </>
         ) : (

--- a/gestor-frontend/src/components/SalaryLineChart.jsx
+++ b/gestor-frontend/src/components/SalaryLineChart.jsx
@@ -75,7 +75,7 @@ export default function SalaryLineChart({ workers = [] }) {
 
   return (
     <div className="w-full">
-      <div className="w-full h-80">
+      <div className="w-full h-80 mb-4">
         <ResponsiveContainer>
           <LineChart data={bins} aria-label="Gráfica de distribución salarial">
             <CartesianGrid strokeDasharray="3 3" />
@@ -94,25 +94,6 @@ export default function SalaryLineChart({ workers = [] }) {
       </div>
       {invalidCount > 0 && (
         <p className="text-sm text-gray-500 mt-2">Registros sin salario: {invalidCount}</p>
-      )}
-
-      {validWorkers.length > 0 && (
-        <table className="mt-4 w-full text-left border-collapse">
-          <thead>
-            <tr>
-              <th className="border px-2 py-1">TRABAJADOR</th>
-              <th className="border px-2 py-1">SALARIO</th>
-            </tr>
-          </thead>
-          <tbody>
-            {validWorkers.map((w) => (
-              <tr key={w.id}>
-                <td className="border px-2 py-1">{w.name}</td>
-                <td className="border px-2 py-1">€{formatCurrency(w.neto)}</td>
-              </tr>
-            ))}
-          </tbody>
-        </table>
       )}
     </div>
   );

--- a/gestor-frontend/src/components/SalaryTable.jsx
+++ b/gestor-frontend/src/components/SalaryTable.jsx
@@ -1,0 +1,27 @@
+import { formatCurrency } from '@/utils/utils';
+
+export default function SalaryTable({ workers = [] }) {
+  const validWorkers = workers.filter((w) => Number.isFinite(w.neto));
+  if (!validWorkers.length) return null;
+
+  return (
+    <div className="overflow-x-auto">
+      <table className="w-full text-left border-collapse text-gray-900">
+        <thead>
+          <tr>
+            <th className="border px-2 py-1">TRABAJADOR</th>
+            <th className="border px-2 py-1">SALARIO</th>
+          </tr>
+        </thead>
+        <tbody>
+          {validWorkers.map((w) => (
+            <tr key={w.id}>
+              <td className="border px-2 py-1">{w.name}</td>
+              <td className="border px-2 py-1">€{formatCurrency(w.neto)}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- ensure worker salary table text uses dark color
- display salary distribution chart and worker table in separate sections

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68aef1f7cfb0832b91cc563bef8a71d9