### PR TITLE
Add externals calendar and API

### DIFF
--- a/gestor-backend/controllers/externo.controller.js
+++ b/gestor-backend/controllers/externo.controller.js
@@ -1,0 +1,27 @@
+const db = require('../models');
+const Externo = db.Externo;
+const { Op } = db.Sequelize;
+
+exports.createOrUpdate = async (req, res) => {
+  const { fecha, cantidad } = req.body;
+  try {
+    await Externo.upsert({ fecha, cantidad });
+    res.json({ fecha, cantidad });
+  } catch (err) {
+    res.status(500).json({ error: 'Error guardando externo' });
+  }
+};
+
+exports.getExternos = async (req, res) => {
+  const { start, end } = req.query;
+  const where = {};
+  if (start && end) {
+    where.fecha = { [Op.between]: [start, end] };
+  }
+  try {
+    const items = await Externo.findAll({ where });
+    res.json(items);
+  } catch (err) {
+    res.status(500).json({ error: 'Error obteniendo externos' });
+  }
+};

--- a/gestor-backend/index.js
+++ b/gestor-backend/index.js
@@ -4,6 +4,7 @@ const dotenv = require('dotenv');
 const horarioRoutes = require('./routes/horario.routes');
 const authRoutes = require('./routes/auth.routes');
 const trabajadorRoutes = require('./routes/trabajador.routes');
+const externoRoutes = require('./routes/externo.routes');
 const db = require('./models');
 
 dotenv.config();
@@ -47,6 +48,7 @@ app.use(express.urlencoded({ extended: true }));
 app.use('/api/auth', authRoutes);
 app.use('/api/trabajadores', trabajadorRoutes);
 app.use('/api/horarios', horarioRoutes);
+app.use('/api/externos', externoRoutes);
 
 // Conexión y sincronización DB
 db.sequelize.authenticate()

--- a/gestor-backend/models/externo.model.js
+++ b/gestor-backend/models/externo.model.js
@@ -1,0 +1,16 @@
+module.exports = (sequelize, DataTypes) => {
+  return sequelize.define('externo', {
+    fecha: {
+      type: DataTypes.DATEONLY,
+      primaryKey: true,
+      allowNull: false,
+    },
+    cantidad: {
+      type: DataTypes.INTEGER,
+      allowNull: false,
+    },
+  }, {
+    freezeTableName: true,
+    timestamps: false,
+  });
+};

--- a/gestor-backend/models/index.js
+++ b/gestor-backend/models/index.js
@@ -20,6 +20,7 @@ db.sequelize = sequelize;
 // Modelos
 db.Trabajador = require('./trabajador.model')(sequelize, DataTypes);
 db.Horario = require('./horario.model')(sequelize, DataTypes);
+db.Externo = require('./externo.model')(sequelize, DataTypes);
 
 // Relaciones
 db.Trabajador.hasMany(db.Horario, { foreignKey: 'trabajador_id' });

--- a/gestor-backend/routes/externo.routes.js
+++ b/gestor-backend/routes/externo.routes.js
@@ -1,0 +1,9 @@
+const express = require('express');
+const router = express.Router();
+const auth = require('../middlewares/auth');
+const externoController = require('../controllers/externo.controller');
+
+router.post('/', auth, externoController.createOrUpdate);
+router.get('/', auth, externoController.getExternos);
+
+module.exports = router;

--- a/gestor-frontend/src/App.jsx
+++ b/gestor-frontend/src/App.jsx
@@ -4,6 +4,7 @@ import Trabajador from './components/Trabajador';
 import ScheduleManager from './components/ScheduleManager';
 import Proyecciones from './components/Proyecciones';
 import Organizacion from './components/Organizacion';
+import Externos from './components/Externos';
 
 function App() {
   return (
@@ -14,6 +15,7 @@ function App() {
         <Route path="/dashboard" element={<ScheduleManager />} />
         <Route path="/proyecciones" element={<Proyecciones />} />
         <Route path="/organizacion" element={<Organizacion />} />
+        <Route path="/externos" element={<Externos />} />
       </Routes>
     </Router>
   );

--- a/gestor-frontend/src/components/ExternoModal.jsx
+++ b/gestor-frontend/src/components/ExternoModal.jsx
@@ -1,0 +1,43 @@
+import React, { useState, useEffect } from 'react';
+import { Dialog } from '@headlessui/react';
+import { format, isValid } from 'date-fns';
+
+export default function ExternoModal({ isOpen, onClose, fecha, onSave, initialCantidad = 0 }) {
+  const [cantidad, setCantidad] = useState(initialCantidad);
+
+  useEffect(() => {
+    setCantidad(initialCantidad);
+  }, [initialCantidad]);
+
+  let formattedDate = 'Fecha inválida';
+  if (fecha && isValid(new Date(fecha))) {
+    formattedDate = format(new Date(fecha), 'dd/MM/yyyy');
+  }
+
+  const handleSave = () => {
+    onSave({ fecha, cantidad: Number(cantidad) });
+    onClose();
+  };
+
+  return (
+    <Dialog open={isOpen} onClose={onClose} className="fixed z-50 inset-0 overflow-y-auto">
+      <div className="flex items-center justify-center min-h-screen p-4 bg-black/40">
+        <Dialog.Panel className="w-full max-w-md rounded-lg shadow-lg p-6 bg-white text-black">
+          <Dialog.Title className="text-lg font-bold mb-2">Externos</Dialog.Title>
+          <p className="text-sm mb-4">Fecha: {formattedDate}</p>
+          <input
+            type="number"
+            min="0"
+            value={cantidad}
+            onChange={(e) => setCantidad(e.target.value)}
+            className="border p-2 rounded w-full text-black"
+          />
+          <div className="mt-4 flex justify-end gap-2">
+            <button onClick={onClose} className="px-4 py-2 rounded bg-gray-200 hover:bg-gray-300">Cancelar</button>
+            <button onClick={handleSave} className="px-4 py-2 rounded bg-blue-600 text-white hover:bg-blue-700">Guardar</button>
+          </div>
+        </Dialog.Panel>
+      </div>
+    </Dialog>
+  );
+}

--- a/gestor-frontend/src/components/Externos.jsx
+++ b/gestor-frontend/src/components/Externos.jsx
@@ -1,0 +1,159 @@
+import React, { useEffect, useState } from 'react';
+import axios from 'axios';
+import { format, startOfMonth, endOfMonth, getDaysInMonth, getDay, differenceInCalendarDays } from 'date-fns';
+import { es } from 'date-fns/locale';
+import Header from '@/components/Header';
+import ExternoModal from '@/components/ExternoModal';
+import { ChevronLeft, ChevronRight } from 'lucide-react';
+
+export default function Externos() {
+  const [currentDate, setCurrentDate] = useState(new Date());
+  const [externos, setExternos] = useState([]);
+  const [selectedDay, setSelectedDay] = useState(null);
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [startRange, setStartRange] = useState('');
+  const [endRange, setEndRange] = useState('');
+  const [average, setAverage] = useState(null);
+
+  const daysInMonth = getDaysInMonth(currentDate);
+  const firstDay = startOfMonth(currentDate);
+  const lastDay = endOfMonth(currentDate);
+  const firstDayIndex = (getDay(firstDay) + 6) % 7;
+
+  const getFechaKey = (day) => format(new Date(currentDate.getFullYear(), currentDate.getMonth(), day), 'yyyy-MM-dd');
+
+  useEffect(() => {
+    const token = localStorage.getItem('token');
+    const start = format(firstDay, 'yyyy-MM-dd');
+    const end = format(lastDay, 'yyyy-MM-dd');
+    axios
+      .get(`${import.meta.env.VITE_API_URL}/externos?start=${start}&end=${end}`, {
+        headers: { Authorization: `Bearer ${token}` },
+      })
+      .then((res) => setExternos(res.data));
+  }, [currentDate, firstDay, lastDay]);
+
+  const groupedExternos = externos.reduce((acc, item) => {
+    acc[item.fecha] = item.cantidad;
+    return acc;
+  }, {});
+
+  const handleDayClick = (day) => {
+    const fecha = getFechaKey(day);
+    const cantidad = groupedExternos[fecha] || 0;
+    setSelectedDay({ fecha, cantidad });
+    setIsModalOpen(true);
+  };
+
+  const handleGuardar = ({ fecha, cantidad }) => {
+    const token = localStorage.getItem('token');
+    axios
+      .post(
+        `${import.meta.env.VITE_API_URL}/externos`,
+        { fecha, cantidad },
+        { headers: { Authorization: `Bearer ${token}` } }
+      )
+      .then(() => {
+        setExternos((prev) => {
+          const otros = prev.filter((e) => e.fecha !== fecha);
+          return [...otros, { fecha, cantidad }];
+        });
+      });
+  };
+
+  const handleCalcularMedia = async () => {
+    if (!startRange || !endRange) return;
+    const token = localStorage.getItem('token');
+    const res = await axios.get(
+      `${import.meta.env.VITE_API_URL}/externos?start=${startRange}&end=${endRange}`,
+      { headers: { Authorization: `Bearer ${token}` } }
+    );
+    const diff = differenceInCalendarDays(new Date(endRange), new Date(startRange)) + 1;
+    const total = res.data.reduce((sum, item) => sum + item.cantidad, 0);
+    setAverage(total / diff);
+  };
+
+  const renderCalendar = () => {
+    const days = [];
+    for (let i = 0; i < firstDayIndex; i++) {
+      days.push(<div key={`empty-${i}`} className="border p-4 bg-transparent" />);
+    }
+    for (let day = 1; day <= daysInMonth; day++) {
+      const dateKey = getFechaKey(day);
+      const cantidad = groupedExternos[dateKey];
+      days.push(
+        <div
+          key={day}
+          className="border p-4 cursor-pointer hover:bg-gray-100 min-h-[80px] flex flex-col"
+          onClick={() => handleDayClick(day)}
+        >
+          <span>{day}</span>
+          {cantidad !== undefined && <span className="text-sm mt-auto">{cantidad} ext</span>}
+        </div>
+      );
+    }
+    return days;
+  };
+
+  return (
+    <div className="min-h-screen bg-gray-50 text-gray-900">
+      <Header />
+      <div className="max-w-4xl mx-auto p-4">
+        <div className="flex justify-between items-center mb-4">
+          <button onClick={() => setCurrentDate(new Date(currentDate.getFullYear(), currentDate.getMonth() - 1, 1))}>
+            <ChevronLeft />
+          </button>
+          <h2 className="text-xl font-bold">
+            {format(currentDate, 'MMMM yyyy', { locale: es })}
+          </h2>
+          <button onClick={() => setCurrentDate(new Date(currentDate.getFullYear(), currentDate.getMonth() + 1, 1))}>
+            <ChevronRight />
+          </button>
+        </div>
+        <div className="grid grid-cols-7 gap-2 text-center">
+          {['Lun', 'Mar', 'Mié', 'Jue', 'Vie', 'Sáb', 'Dom'].map((d) => (
+            <div key={d} className="font-semibold">
+              {d}
+            </div>
+          ))}
+          {renderCalendar()}
+        </div>
+        <div className="mt-6">
+          <h3 className="text-lg font-bold mb-2">Media de Externos</h3>
+          <div className="flex gap-2 items-center">
+            <input
+              type="date"
+              value={startRange}
+              onChange={(e) => setStartRange(e.target.value)}
+              className="border p-2 rounded text-black"
+            />
+            <input
+              type="date"
+              value={endRange}
+              onChange={(e) => setEndRange(e.target.value)}
+              className="border p-2 rounded text-black"
+            />
+            <button
+              onClick={handleCalcularMedia}
+              className="bg-blue-500 text-white px-4 py-2 rounded"
+            >
+              Calcular
+            </button>
+          </div>
+          {average !== null && (
+            <p className="mt-2">Media: {average.toFixed(2)}</p>
+          )}
+        </div>
+      </div>
+      {selectedDay && (
+        <ExternoModal
+          isOpen={isModalOpen}
+          onClose={() => setIsModalOpen(false)}
+          fecha={selectedDay.fecha}
+          initialCantidad={selectedDay.cantidad}
+          onSave={handleGuardar}
+        />
+      )}
+    </div>
+  );
+}

--- a/gestor-frontend/src/components/Header.jsx
+++ b/gestor-frontend/src/components/Header.jsx
@@ -8,7 +8,8 @@ import {
   TrendingUp,
   Building2,
   Menu,
-  Bell
+  Bell,
+  UserCheck
 } from 'lucide-react';
 // eslint-disable-next-line no-unused-vars
 import { motion, AnimatePresence } from 'framer-motion';
@@ -130,6 +131,10 @@ export default function Header() {
                   <Building2 className="mr-2 h-5 w-5" />
                   Organización
                 </NavLink>
+                <NavLink to="/externos" className={navLinkClasses}>
+                  <UserCheck className="mr-2 h-5 w-5" />
+                  Externos
+                </NavLink>
               </div>
             </nav>
           </div>
@@ -240,6 +245,9 @@ export default function Header() {
               </NavLink>
               <NavLink to="/organizacion" className={navLinkClasses}>
                 <Building2 className="mr-2 h-5 w-5" /> Organización
+              </NavLink>
+              <NavLink to="/externos" className={navLinkClasses}>
+                <UserCheck className="mr-2 h-5 w-5" /> Externos
               </NavLink>
               <button
                 onClick={handleLogout}


### PR DESCRIPTION
## Summary
- add backend model, routes and controller to store daily external worker counts
- implement Externos calendar view with modal and average calculation
- expose new navigation link to access Externos section

## Testing
- `npm test` (backend) *(fails: Error: no test specified)*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68b85527bf0c832b993c68adde09183f