### PR TITLE
feat(frontend): style externos calendar like schedule manager

### DIFF
--- a/gestor-frontend/src/components/Externos.jsx
+++ b/gestor-frontend/src/components/Externos.jsx
@@ -1,6 +1,13 @@
 import React, { useEffect, useState } from 'react';
 import axios from 'axios';
-import { format, startOfMonth, endOfMonth, getDaysInMonth, getDay, differenceInCalendarDays } from 'date-fns';
+import {
+  format,
+  startOfMonth,
+  endOfMonth,
+  getDaysInMonth,
+  getDay,
+  differenceInCalendarDays
+} from 'date-fns';
 import { es } from 'date-fns/locale';
 import Header from '@/components/Header';
 import ExternoModal from '@/components/ExternoModal';
@@ -82,7 +89,9 @@ export default function Externos() {
   const renderCalendar = () => {
     const days = [];
     for (let i = 0; i < firstDayIndex; i++) {
-      days.push(<div key={`empty-${i}`} className="border p-4 bg-transparent" />);
+      days.push(
+        <div key={`empty-${i}`} className="border rounded-lg p-2 bg-transparent" />
+      );
     }
     for (let day = 1; day <= daysInMonth; day++) {
       const dateKey = getFechaKey(day);
@@ -90,11 +99,15 @@ export default function Externos() {
       days.push(
         <div
           key={day}
-          className="border p-4 cursor-pointer hover:bg-gray-100 min-h-[80px] flex flex-col"
+          className="cursor-pointer border rounded-lg h-24 w-full p-2 text-sm font-medium flex flex-col items-center justify-center relative hover:shadow-md transition-all duration-200"
           onClick={() => handleDayClick(day)}
         >
-          <span>{day}</span>
-          {cantidad !== undefined && <span className="text-sm mt-auto">{cantidad} ext</span>}
+          <span className="absolute top-1 left-1 text-xs font-semibold text-gray-500">
+            {day}
+          </span>
+          {cantidad !== undefined && (
+            <span className="text-sm mt-auto">{cantidad} ext</span>
+          )}
         </div>
       );
     }
@@ -102,31 +115,57 @@ export default function Externos() {
   };
 
   return (
-    <div className="min-h-screen bg-gray-50 text-gray-900">
+    <>
       <Header />
-      <div className="max-w-4xl mx-auto p-4">
-        <div className="flex justify-between items-center mb-4">
-          <button onClick={() => setCurrentDate(new Date(currentDate.getFullYear(), currentDate.getMonth() - 1, 1))}>
-            <ChevronLeft />
-          </button>
-          <h2 className="text-xl font-bold">
-            {format(currentDate, 'MMMM yyyy', { locale: es })}
-          </h2>
-          <button onClick={() => setCurrentDate(new Date(currentDate.getFullYear(), currentDate.getMonth() + 1, 1))}>
-            <ChevronRight />
-          </button>
+      <div className="min-h-screen bg-slate-100 p-4 sm:p-6 text-gray-900">
+        <div className="w-full max-w-5xl mx-auto mb-4 sm:mb-6 text-center">
+          <h1 className="text-2xl sm:text-3xl font-bold bg-gradient-to-r from-purple-600 to-pink-500 bg-clip-text text-transparent">
+            Gestor de Externos
+          </h1>
+          <p className="text-gray-600 mt-2">Controla y planifica los externos diarios.</p>
         </div>
-        <div className="grid grid-cols-7 gap-2 text-center">
-          {['Lun', 'Mar', 'Mié', 'Jue', 'Vie', 'Sáb', 'Dom'].map((d) => (
-            <div key={d} className="font-semibold">
-              {d}
-            </div>
-          ))}
-          {renderCalendar()}
+
+        <div className="w-full bg-white rounded-xl shadow-xl max-w-5xl mx-auto p-4 sm:p-6">
+          <div className="flex items-center justify-between mb-6">
+            <button
+              onClick={() =>
+                setCurrentDate(
+                  new Date(currentDate.getFullYear(), currentDate.getMonth() - 1, 1)
+                )
+              }
+              className="p-2 bg-white border rounded shadow hover:bg-gray-50"
+              aria-label="Mes anterior"
+            >
+              <ChevronLeft className="w-5 h-5 text-gray-600" />
+            </button>
+            <strong className="text-xl text-gray-700">
+              {format(currentDate, 'MMMM yyyy', { locale: es })}
+            </strong>
+            <button
+              onClick={() =>
+                setCurrentDate(
+                  new Date(currentDate.getFullYear(), currentDate.getMonth() + 1, 1)
+                )
+              }
+              className="p-2 bg-white border rounded shadow hover:bg-gray-50"
+              aria-label="Mes siguiente"
+            >
+              <ChevronRight className="w-5 h-5 text-gray-600" />
+            </button>
+          </div>
+
+          <div className="grid grid-cols-7 gap-2 text-center text-sm font-medium text-gray-500 mb-2">
+            {['Lun', 'Mar', 'Mié', 'Jue', 'Vie', 'Sáb', 'Dom'].map((d) => (
+              <div key={d}>{d}</div>
+            ))}
+          </div>
+
+          <div className="grid grid-cols-7 gap-2">{renderCalendar()}</div>
         </div>
-        <div className="mt-6">
-          <h3 className="text-lg font-bold mb-2">Media de Externos</h3>
-          <div className="flex gap-2 items-center">
+
+        <div className="w-full bg-white rounded-xl shadow-xl max-w-5xl mx-auto p-4 sm:p-6 mt-6">
+          <h3 className="text-lg font-bold mb-4">Media de Externos</h3>
+          <div className="flex flex-col sm:flex-row gap-2 items-center">
             <input
               type="date"
               value={startRange}
@@ -172,6 +211,6 @@ export default function Externos() {
           onSave={handleGuardar}
         />
       )}
-    </div>
+    </>
   );
 }


### PR DESCRIPTION
## Summary
- wrap Externos calendar and stats in styled containers similar to ScheduleManager
- improve day cell styling for clearer layout

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b859fb6784832baf13535b40f46371