### PR TITLE
feat: manage multiple externals per day

### DIFF
--- a/gestor-backend/controllers/externo.controller.js
+++ b/gestor-backend/controllers/externo.controller.js
@@ -28,3 +28,28 @@ exports.getExternos = async (req, res) => {
     res.status(500).json({ error: 'Error obteniendo externos' });
   }
 };
+
+exports.getEmpresas = async (req, res) => {
+  try {
+    const items = await Externo.findAll({
+      attributes: [
+        [db.Sequelize.fn('DISTINCT', db.Sequelize.col('nombre_empresa_externo')), 'nombre_empresa_externo'],
+      ],
+      order: [['nombre_empresa_externo', 'ASC']],
+    });
+    const empresas = items.map((i) => i.get('nombre_empresa_externo'));
+    res.json(empresas);
+  } catch (err) {
+    res.status(500).json({ error: 'Error obteniendo empresas' });
+  }
+};
+
+exports.deleteExterno = async (req, res) => {
+  const { fecha, nombre_empresa_externo } = req.body;
+  try {
+    await Externo.destroy({ where: { fecha, nombre_empresa_externo } });
+    res.json({ success: true });
+  } catch (err) {
+    res.status(500).json({ error: 'Error eliminando externo' });
+  }
+};

--- a/gestor-backend/routes/externo.routes.js
+++ b/gestor-backend/routes/externo.routes.js
@@ -5,5 +5,7 @@ const externoController = require('../controllers/externo.controller');
 
 router.post('/', auth, externoController.createOrUpdate);
 router.get('/', auth, externoController.getExternos);
+router.get('/empresas', auth, externoController.getEmpresas);
+router.delete('/', auth, externoController.deleteExterno);
 
 module.exports = router;

--- a/gestor-frontend/src/components/ExternoModal.jsx
+++ b/gestor-frontend/src/components/ExternoModal.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import { Dialog } from '@headlessui/react';
 import { format, isValid } from 'date-fns';
 
@@ -7,24 +7,39 @@ export default function ExternoModal({
   onClose,
   fecha,
   onSave,
-  initialCantidad = 0,
-  initialNombre = '',
+  initialItems = [],
+  companies = [],
 }) {
-  const [cantidad, setCantidad] = useState(initialCantidad);
-  const [nombre, setNombre] = useState(initialNombre);
+  const [items, setItems] = useState(initialItems);
 
   useEffect(() => {
-    setCantidad(initialCantidad);
-    setNombre(initialNombre);
-  }, [initialCantidad, initialNombre]);
+    setItems(initialItems);
+  }, [initialItems]);
 
   let formattedDate = 'Fecha inválida';
   if (fecha && isValid(new Date(fecha))) {
     formattedDate = format(new Date(fecha), 'dd/MM/yyyy');
   }
 
+  const handleChange = (index, field, value) => {
+    setItems((prev) =>
+      prev.map((item, i) => (i === index ? { ...item, [field]: value } : item))
+    );
+  };
+
+  const handleAdd = () => {
+    setItems((prev) => [
+      ...prev,
+      { nombre_empresa_externo: '', cantidad: 0 },
+    ]);
+  };
+
+  const handleRemove = (index) => {
+    setItems((prev) => prev.filter((_, i) => i !== index));
+  };
+
   const handleSave = () => {
-    onSave({ fecha, cantidad: Number(cantidad), nombre_empresa_externo: nombre });
+    onSave({ fecha, items });
     onClose();
   };
 
@@ -34,26 +49,67 @@ export default function ExternoModal({
         <Dialog.Panel className="w-full max-w-md rounded-lg shadow-lg p-6 bg-white text-black">
           <Dialog.Title className="text-lg font-bold mb-2">Externos</Dialog.Title>
           <p className="text-sm mb-4">Fecha: {formattedDate}</p>
-          <input
-            type="text"
-            value={nombre}
-            onChange={(e) => setNombre(e.target.value)}
-            className="border p-2 rounded w-full text-black mb-2"
-            placeholder="Nombre de la empresa"
-          />
-          <input
-            type="number"
-            min="0"
-            value={cantidad}
-            onChange={(e) => setCantidad(e.target.value)}
-            className="border p-2 rounded w-full text-black"
-          />
+
+          {items.map((item, index) => (
+            <div key={index} className="flex items-center gap-2 mb-2">
+              <select
+                value={item.nombre_empresa_externo}
+                onChange={(e) =>
+                  handleChange(index, 'nombre_empresa_externo', e.target.value)
+                }
+                className="border p-2 rounded text-black flex-1"
+              >
+                <option value="" disabled>
+                  Empresa
+                </option>
+                {companies.map((name) => (
+                  <option key={name} value={name}>
+                    {name}
+                  </option>
+                ))}
+              </select>
+              <input
+                type="number"
+                min="0"
+                value={item.cantidad}
+                onChange={(e) => handleChange(index, 'cantidad', e.target.value)}
+                className="border p-2 rounded w-24 text-black"
+              />
+              <button
+                type="button"
+                onClick={() => handleRemove(index)}
+                className="text-red-600 px-2"
+              >
+                ✕
+              </button>
+            </div>
+          ))}
+
+          <button
+            type="button"
+            onClick={handleAdd}
+            className="mt-2 px-4 py-2 rounded bg-green-500 text-white hover:bg-green-600"
+          >
+            Añadir
+          </button>
+
           <div className="mt-4 flex justify-end gap-2">
-            <button onClick={onClose} className="px-4 py-2 rounded bg-gray-200 hover:bg-gray-300">Cancelar</button>
-            <button onClick={handleSave} className="px-4 py-2 rounded bg-blue-600 text-white hover:bg-blue-700">Guardar</button>
+            <button
+              onClick={onClose}
+              className="px-4 py-2 rounded bg-gray-200 hover:bg-gray-300"
+            >
+              Cancelar
+            </button>
+            <button
+              onClick={handleSave}
+              className="px-4 py-2 rounded bg-blue-600 text-white hover:bg-blue-700"
+            >
+              Guardar
+            </button>
           </div>
         </Dialog.Panel>
       </div>
     </Dialog>
   );
 }
+


### PR DESCRIPTION
## Summary
- allow selecting existing external companies for average calculation
- support multiple company entries per day with quantity association
- add endpoints to list and remove external company records

## Testing
- `npm test` (backend) *(fails: Error: no test specified)*
- `npm test` (frontend) *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c14bb1e090832bbd782ea78ba85789