### PR TITLE
Allow multiple externals per day

### DIFF
--- a/gestor-backend/controllers/externo.controller.js
+++ b/gestor-backend/controllers/externo.controller.js
@@ -5,7 +5,15 @@ const { Op } = db.Sequelize;
 exports.createOrUpdate = async (req, res) => {
   const { fecha, cantidad, nombre_empresa_externo } = req.body;
   try {
-    await Externo.upsert({ fecha, cantidad, nombre_empresa_externo });
+    const existing = await Externo.findOne({
+      where: { fecha, nombre_empresa_externo }
+    });
+    if (existing) {
+      existing.cantidad = cantidad;
+      await existing.save();
+    } else {
+      await Externo.create({ fecha, cantidad, nombre_empresa_externo });
+    }
     res.json({ fecha, cantidad, nombre_empresa_externo });
   } catch (err) {
     res.status(500).json({ error: 'Error guardando externo' });

--- a/gestor-backend/models/externo.model.js
+++ b/gestor-backend/models/externo.model.js
@@ -1,13 +1,16 @@
 module.exports = (sequelize, DataTypes) => {
   return sequelize.define('externo', {
+    id: {
+      type: DataTypes.INTEGER,
+      autoIncrement: true,
+      primaryKey: true,
+    },
     fecha: {
       type: DataTypes.DATEONLY,
-      primaryKey: true,
       allowNull: false,
     },
     nombre_empresa_externo: {
       type: DataTypes.STRING,
-      primaryKey: true,
       allowNull: false,
     },
     cantidad: {

--- a/gestor-frontend/src/components/ExternoModal.jsx
+++ b/gestor-frontend/src/components/ExternoModal.jsx
@@ -10,10 +10,10 @@ export default function ExternoModal({
   initialItems = [],
   companies = [],
 }) {
-  const [items, setItems] = useState(initialItems);
+  const [items, setItems] = useState([...initialItems, { nombre_empresa_externo: '', cantidad: 0 }]);
 
   useEffect(() => {
-    setItems(initialItems);
+    setItems([...initialItems, { nombre_empresa_externo: '', cantidad: 0 }]);
   }, [initialItems]);
 
   let formattedDate = 'Fecha inválida';
@@ -39,7 +39,10 @@ export default function ExternoModal({
   };
 
   const handleSave = () => {
-    onSave({ fecha, items });
+    const validItems = items.filter(
+      (i) => i.nombre_empresa_externo && Number(i.cantidad) > 0
+    );
+    onSave({ fecha, items: validItems });
     onClose();
   };
 

--- a/gestor-frontend/src/components/Externos.jsx
+++ b/gestor-frontend/src/components/Externos.jsx
@@ -138,8 +138,7 @@ export default function Externos() {
     for (let day = 1; day <= daysInMonth; day++) {
       const dateKey = getFechaKey(day);
       const data = groupedExternos[dateKey];
-      const total = data ? data.reduce((sum, i) => sum + i.cantidad, 0) : 0;
-      const isMarked = total > 0;
+      const isMarked = data && data.length > 0;
       days.push(
         <div
           key={day}
@@ -149,9 +148,6 @@ export default function Externos() {
           <span className="absolute top-1 left-1 text-xs font-semibold text-gray-500">
             {day}
           </span>
-          {isMarked && (
-            <span className="text-xl font-bold text-teal-600 mt-auto">{total}</span>
-          )}
         </div>
       );
     }


### PR DESCRIPTION
## Summary
- avoid overwriting externals by checking existing records and creating new ones
- add auto-increment id for externals table
- hide total count from externals calendar and preload blank entry in modal

## Testing
- `cd gestor-backend && npm test` (fails: Error: no test specified)
- `cd gestor-frontend && npm test` (fails: Missing script: "test")
- `cd gestor-frontend && npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c15b50c86c832b9019fb3cbad9ec14