### PR TITLE
feat: exportar trabajadores con campos seleccionables

### DIFF
--- a/gestor-frontend/src/utils/exportWorkerExcel.js
+++ b/gestor-frontend/src/utils/exportWorkerExcel.js
@@ -1,5 +1,29 @@
 import * as XLSX from 'xlsx-js-style';
 
+const borderStyle = {
+  top: { style: 'thin', color: { rgb: '000000' } },
+  bottom: { style: 'thin', color: { rgb: '000000' } },
+  left: { style: 'thin', color: { rgb: '000000' } },
+  right: { style: 'thin', color: { rgb: '000000' } }
+};
+
+const formatValueForExcel = (value) => {
+  if (value === null || value === undefined) return '';
+  if (typeof value === 'boolean') return value ? 'Sí' : 'No';
+  return value;
+};
+
+const autoSizeColumns = (rows) => {
+  if (!rows.length) return [];
+  const columnCount = rows[0].length;
+  const widths = Array.from({ length: columnCount }, (_, columnIndex) => {
+    const columnValues = rows.map(row => `${row[columnIndex] ?? ''}`);
+    const maxLength = columnValues.reduce((max, value) => Math.max(max, value.length), 0);
+    return { wch: Math.min(Math.max(maxLength + 4, 12), 45) };
+  });
+  return widths;
+};
+
 export function exportWorkerToExcel(trabajador, filePath) {
   const fields = [
     'nombre', 'dni', 'correo_electronico', 'telefono', 'tipo_trabajador',
@@ -10,30 +34,59 @@ export function exportWorkerToExcel(trabajador, filePath) {
     'condiciones', 'pais', 'epis', 'fecha_epis', 'empresa'
   ];
 
-  const aoa = [fields, fields.map(f => trabajador[f] ?? '')];
+  const aoa = [fields, fields.map(f => formatValueForExcel(trabajador[f]))];
   const wb = XLSX.utils.book_new();
   const ws = XLSX.utils.aoa_to_sheet(aoa);
-  ws['!cols'] = fields.map(() => ({ wch: 20 }));
+  ws['!cols'] = autoSizeColumns(aoa);
 
-  const borderStyle = {
-    top: { style: 'thin', color: { rgb: '000000' } },
-    bottom: { style: 'thin', color: { rgb: '000000' } },
-    left: { style: 'thin', color: { rgb: '000000' } },
-    right: { style: 'thin', color: { rgb: '000000' } }
-  };
-
-  for (let c = 0; c < fields.length; c++) {
-    const headerCell = ws[XLSX.utils.encode_cell({ r: 0, c })];
-    if (headerCell) {
-      headerCell.s = { font: { bold: true }, border: borderStyle };
-    }
-    const dataCell = ws[XLSX.utils.encode_cell({ r: 1, c })];
-    if (dataCell) {
-      dataCell.s = { border: borderStyle };
+  for (let r = 0; r < aoa.length; r++) {
+    for (let c = 0; c < fields.length; c++) {
+      const cell = ws[XLSX.utils.encode_cell({ r, c })];
+      if (!cell) continue;
+      cell.s = {
+        border: borderStyle,
+        font: r === 0 ? { bold: true } : undefined
+      };
     }
   }
 
   XLSX.utils.book_append_sheet(wb, ws, 'Trabajador');
   const name = filePath || `trabajador_${trabajador.nombre}.xlsx`;
   XLSX.writeFile(wb, name);
+}
+
+export function exportWorkersSelectionToExcel(trabajadores, selectedFields, {
+  fieldLabels = {},
+  fileName
+} = {}) {
+  if (!Array.isArray(trabajadores) || trabajadores.length === 0) {
+    throw new Error('No hay trabajadores para exportar');
+  }
+
+  if (!Array.isArray(selectedFields) || selectedFields.length === 0) {
+    throw new Error('No se han especificado campos para exportar');
+  }
+
+  const headers = selectedFields.map(field => fieldLabels[field] || field);
+  const rows = trabajadores.map(trabajador => selectedFields.map(field => formatValueForExcel(trabajador[field])));
+  const aoa = [headers, ...rows];
+
+  const wb = XLSX.utils.book_new();
+  const ws = XLSX.utils.aoa_to_sheet(aoa);
+  ws['!cols'] = autoSizeColumns(aoa);
+
+  for (let r = 0; r < aoa.length; r++) {
+    for (let c = 0; c < headers.length; c++) {
+      const cell = ws[XLSX.utils.encode_cell({ r, c })];
+      if (!cell) continue;
+      cell.s = {
+        border: borderStyle,
+        font: r === 0 ? { bold: true } : undefined
+      };
+    }
+  }
+
+  XLSX.utils.book_append_sheet(wb, ws, 'Trabajadores');
+  const safeFileName = fileName || `trabajadores_${new Date().toISOString().split('T')[0]}.xlsx`;
+  XLSX.writeFile(wb, safeFileName);
 }


### PR DESCRIPTION
## Summary
- añade un panel en Gestionar Trabajadores para elegir los campos que se exportan y generar el Excel con la lista filtrada
- actualiza las utilidades de exportación a Excel para admitir selección de columnas y mejorar el formateo de valores

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ca7735d6bc832bb353947638b1a1dc