### PR TITLE
Alinear modelo Externo con tabla existente

### DIFF
--- a/gestor-backend/models/externo.model.js
+++ b/gestor-backend/models/externo.model.js
@@ -1,13 +1,9 @@
 module.exports = (sequelize, DataTypes) => {
   return sequelize.define('externo', {
-    id: {
-      type: DataTypes.INTEGER,
-      autoIncrement: true,
-      primaryKey: true,
-    },
     fecha: {
       type: DataTypes.DATEONLY,
       allowNull: false,
+      primaryKey: true,
     },
     nombre_empresa_externo: {
       type: DataTypes.STRING,


### PR DESCRIPTION
## Summary
- eliminar el campo autoincremental `id` del modelo `externo`
- declarar `fecha` como clave primaria para ajustarse al esquema real de la tabla

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ca82e2d314832b9d3d6cabdde97c43