### PR TITLE
Fix externos persistence by adjusting schema and upsert logic

### DIFF
--- a/gestor-backend/index.js
+++ b/gestor-backend/index.js
@@ -54,7 +54,7 @@ app.use('/api/externos', externoRoutes);
 db.sequelize.authenticate()
   .then(() => {
     console.log('✅ Conectado a la base de datos');
-    return db.sequelize.sync();
+    return db.sequelize.sync({ alter: true });
   })
   .then(() => {
     console.log('🗄️ Base de datos sincronizada');

--- a/gestor-backend/models/externo.model.js
+++ b/gestor-backend/models/externo.model.js
@@ -1,20 +1,34 @@
 module.exports = (sequelize, DataTypes) => {
-  return sequelize.define('externo', {
-    fecha: {
-      type: DataTypes.DATEONLY,
-      allowNull: false,
-      primaryKey: true,
+  return sequelize.define(
+    'externo',
+    {
+      id: {
+        type: DataTypes.INTEGER,
+        autoIncrement: true,
+        primaryKey: true,
+      },
+      fecha: {
+        type: DataTypes.DATEONLY,
+        allowNull: false,
+      },
+      nombre_empresa_externo: {
+        type: DataTypes.STRING,
+        allowNull: false,
+      },
+      cantidad: {
+        type: DataTypes.INTEGER,
+        allowNull: false,
+      },
     },
-    nombre_empresa_externo: {
-      type: DataTypes.STRING,
-      allowNull: false,
-    },
-    cantidad: {
-      type: DataTypes.INTEGER,
-      allowNull: false,
-    },
-  }, {
-    freezeTableName: true,
-    timestamps: false,
-  });
+    {
+      freezeTableName: true,
+      timestamps: false,
+      indexes: [
+        {
+          unique: true,
+          fields: ['fecha', 'nombre_empresa_externo'],
+        },
+      ],
+    }
+  );
 };


### PR DESCRIPTION
## Summary
- add an internal id and unique constraint so externos can store multiple empresas por fecha sin conflictos
- switch externos create/update flow to validated upsert calls and trim incoming nombres antes de consultar
- enable sequelize sync with alter to aplicar los cambios de esquema automáticamente al arrancar el backend

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68cbb9ea6220832ba429dee9b1655397