### PR TITLE
Fix externo model primary key definition

### DIFF
--- a/gestor-backend/models/externo.model.js
+++ b/gestor-backend/models/externo.model.js
@@ -2,18 +2,15 @@ module.exports = (sequelize, DataTypes) => {
   return sequelize.define(
     'externo',
     {
-      id: {
-        type: DataTypes.INTEGER,
-        autoIncrement: true,
-        primaryKey: true,
-      },
       fecha: {
         type: DataTypes.DATEONLY,
         allowNull: false,
+        primaryKey: true,
       },
       nombre_empresa_externo: {
         type: DataTypes.STRING,
         allowNull: false,
+        primaryKey: true,
       },
       cantidad: {
         type: DataTypes.INTEGER,


### PR DESCRIPTION
## Summary
- remove the auto-increment id column from the externo Sequelize model
- mark fecha and nombre_empresa_externo as the composite primary key to match the existing table schema

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68cbc16a28d0832bb1688c3ee7098cda