### PR TITLE
Fix externo primary key definition

### DIFF
--- a/gestor-backend/models/externo.model.js
+++ b/gestor-backend/models/externo.model.js
@@ -2,15 +2,19 @@ module.exports = (sequelize, DataTypes) => {
   return sequelize.define(
     'externo',
     {
+      id: {
+        type: DataTypes.INTEGER,
+        autoIncrement: true,
+        allowNull: false,
+        primaryKey: true,
+      },
       fecha: {
         type: DataTypes.DATEONLY,
         allowNull: false,
-        primaryKey: true,
       },
       nombre_empresa_externo: {
         type: DataTypes.STRING,
         allowNull: false,
-        primaryKey: true,
       },
       cantidad: {
         type: DataTypes.INTEGER,


### PR DESCRIPTION
## Summary
- add a surrogate auto-increment id primary key for the `externo` model
- keep the unique constraint on the combination of `fecha` and `nombre_empresa_externo`
- ensure upserts and deletes continue to target records by the logical unique pair

## Testing
- no automated tests were run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68cbcb5d9edc832b8267e1494f1504a3