### PR TITLE
Fix externo model primary key definition

### DIFF
--- a/gestor-backend/models/externo.model.js
+++ b/gestor-backend/models/externo.model.js
@@ -2,19 +2,15 @@ module.exports = (sequelize, DataTypes) => {
   return sequelize.define(
     'externo',
     {
-      id: {
-        type: DataTypes.INTEGER,
-        autoIncrement: true,
-        allowNull: false,
-        primaryKey: true,
-      },
       fecha: {
         type: DataTypes.DATEONLY,
         allowNull: false,
+        primaryKey: true,
       },
       nombre_empresa_externo: {
         type: DataTypes.STRING,
         allowNull: false,
+        primaryKey: true,
       },
       cantidad: {
         type: DataTypes.INTEGER,


### PR DESCRIPTION
## Summary
- remove the automatically generated id column from the externo Sequelize model
- mark fecha and nombre_empresa_externo as the composite primary key so Sequelize matches the existing table schema

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d3f57c6c28832b9a8c773e65b461eb