### PR TITLE
Add paid hours tracking to schedule manager

### DIFF
--- a/gestor-backend/controllers/horario.controller.js
+++ b/gestor-backend/controllers/horario.controller.js
@@ -14,7 +14,19 @@ exports.getHorariosByTrabajador = async (req, res) => {
 };
 exports.createOrUpdateHorarios = async (req, res) => {
   try {
-    const { trabajador_id, fecha, horarios, festivo, vacaciones, bajamedica, proyecto_nombre, horanegativa = 0, dianegativo = false } = req.body;
+    const {
+      trabajador_id,
+      fecha,
+      horarios,
+      festivo,
+      vacaciones,
+      bajamedica,
+      proyecto_nombre,
+      horanegativa = 0,
+      dianegativo = false,
+      pagada = false,
+      horas_pagadas = 0
+    } = req.body;
 
     // Borrar los horarios anteriores del mismo día
     await Horario.destroy({
@@ -35,7 +47,9 @@ exports.createOrUpdateHorarios = async (req, res) => {
           bajamedica: bajamedica || false,
           proyecto_nombre: proyecto_nombre || null,
           horanegativa,
-          dianegativo
+          dianegativo,
+          pagada: pagada || false,
+          horas_pagadas: pagada ? horas_pagadas || 0 : 0
         });
       });
     } else if (festivo) {
@@ -50,7 +64,9 @@ exports.createOrUpdateHorarios = async (req, res) => {
         bajamedica: false,
         proyecto_nombre: proyecto_nombre || null,
         horanegativa,
-        dianegativo
+        dianegativo,
+        pagada: pagada || false,
+        horas_pagadas: pagada ? horas_pagadas || 0 : 0
       });
     } else if (vacaciones) {
       // Registrar el día como vacaciones sin horas
@@ -64,7 +80,9 @@ exports.createOrUpdateHorarios = async (req, res) => {
         bajamedica: false,
         proyecto_nombre: proyecto_nombre || null,
         horanegativa,
-        dianegativo
+        dianegativo,
+        pagada: pagada || false,
+        horas_pagadas: pagada ? horas_pagadas || 0 : 0
       });
     } else if (bajamedica) {
       nuevos.push({
@@ -77,7 +95,9 @@ exports.createOrUpdateHorarios = async (req, res) => {
         bajamedica: true,
         proyecto_nombre: proyecto_nombre || null,
         horanegativa,
-        dianegativo
+        dianegativo,
+        pagada: pagada || false,
+        horas_pagadas: pagada ? horas_pagadas || 0 : 0
       });
     }
     // Permitir asignar un proyecto sin intervalos
@@ -92,7 +112,9 @@ exports.createOrUpdateHorarios = async (req, res) => {
         bajamedica: false,
         proyecto_nombre,
         horanegativa,
-        dianegativo
+        dianegativo,
+        pagada: pagada || false,
+        horas_pagadas: pagada ? horas_pagadas || 0 : 0
       });
     } else if (horanegativa > 0 || dianegativo) {
       // Registrar horas o día negativo sin intervalos
@@ -107,6 +129,8 @@ exports.createOrUpdateHorarios = async (req, res) => {
         proyecto_nombre: proyecto_nombre || null,
         horanegativa,
         dianegativo,
+        pagada: pagada || false,
+        horas_pagadas: pagada ? horas_pagadas || 0 : 0
       });
     }
 

--- a/gestor-backend/models/horario.model.js
+++ b/gestor-backend/models/horario.model.js
@@ -42,6 +42,14 @@ module.exports = (sequelize, DataTypes) => {
       type: DataTypes.BOOLEAN,
       defaultValue: false,
     },
+    pagada: {
+      type: DataTypes.BOOLEAN,
+      defaultValue: false,
+    },
+    horas_pagadas: {
+      type: DataTypes.DECIMAL(6, 2),
+      defaultValue: 0,
+    },
     proyecto_nombre: {
       type: DataTypes.STRING,
       allowNull: true,

--- a/gestor-frontend/src/components/HorarioModal.jsx
+++ b/gestor-frontend/src/components/HorarioModal.jsx
@@ -15,6 +15,8 @@ export default function HorarioModal({
   initialBaja = false,
   initialHoraNegativa = 0,
   initialDiaNegativo = false,
+  initialPagada = false,
+  initialHorasPagadas = 0,
   workers = []
 }) {
   const [intervals, setIntervals] = useState([]);
@@ -27,6 +29,8 @@ export default function HorarioModal({
   const [extraDates, setExtraDates] = useState([]);
   const [useNegative, setUseNegative] = useState(false);
   const [negativeHours, setNegativeHours] = useState('');
+  const [isPaid, setIsPaid] = useState(false);
+  const [paidHours, setPaidHours] = useState('');
 
   const parseHoursInput = (val) => {
     if (!val) return 0;
@@ -60,6 +64,8 @@ export default function HorarioModal({
     setIsBaja(initialBaja);
     setUseNegative(initialHoraNegativa > 0 || initialDiaNegativo);
     setNegativeHours(initialHoraNegativa ? formatHoursInput(initialHoraNegativa) : '');
+    setIsPaid(initialPagada);
+    setPaidHours(initialPagada && initialHorasPagadas ? formatHoursInput(initialHorasPagadas) : '');
 
   // ✅ Detectar el proyecto si todos los intervalos tienen el mismo nombre
   if (initialData.length > 0 && initialData.every(i => i.proyecto_nombre === initialData[0].proyecto_nombre)) {
@@ -69,7 +75,7 @@ export default function HorarioModal({
     setProyectoNombre('');
     setEditarProyecto(false);
   }
-  }, [initialData, initialFestivo, initialVacaciones, initialBaja, fecha, initialHoraNegativa, initialDiaNegativo]);
+  }, [initialData, initialFestivo, initialVacaciones, initialBaja, fecha, initialHoraNegativa, initialDiaNegativo, initialPagada, initialHorasPagadas]);
 
 
   const handleAddInterval = () => {
@@ -110,6 +116,7 @@ export default function HorarioModal({
 
   const handleSave = () => {
     const parsedNegative = useNegative ? parseHoursInput(negativeHours) : 0;
+    const parsedPaid = isPaid ? Math.max(parseHoursInput(paidHours), 0) : 0;
     onSave({
       fecha,
       intervals,
@@ -119,6 +126,8 @@ export default function HorarioModal({
       proyecto_nombre: proyectoNombre?.trim() || null,
       horaNegativa: parsedNegative,
       diaNegativo: useNegative && parsedNegative === 0,
+      pagada: isPaid,
+      horasPagadas: parsedPaid,
       trabajadoresExtra: extraWorkers.filter(Boolean),
       fechasExtra: extraDates.filter(Boolean)
     });
@@ -136,6 +145,8 @@ export default function HorarioModal({
     setExtraDates([]);
     setUseNegative(false);
     setNegativeHours('');
+    setIsPaid(false);
+    setPaidHours('');
   };
 
   const totalHoras = intervals.reduce((sum, intv) => {
@@ -240,6 +251,25 @@ export default function HorarioModal({
               />
               Marcar como Baja Médica
             </label>
+
+            <label className="flex items-center gap-2 mt-3">
+              <input
+                type="checkbox"
+                checked={isPaid}
+                onChange={(e) => setIsPaid(e.target.checked)}
+              />
+              Marcar horas como pagadas
+            </label>
+
+            {isPaid && (
+              <input
+                type="text"
+                value={paidHours}
+                onChange={(e) => setPaidHours(e.target.value)}
+                placeholder="Horas pagadas (HH,MM)"
+                className="p-2 border border-gray-300 rounded w-full mt-1"
+              />
+            )}
 
             <label className="flex flex-col gap-2 mt-3">
               <div className="flex items-center gap-2">

--- a/gestor-frontend/src/components/HorasResumen.jsx
+++ b/gestor-frontend/src/components/HorasResumen.jsx
@@ -69,7 +69,7 @@ export function HoursSummary({ currentDate, scheduleData, onDownload }) {
   const year = getYear(currentDate);
   const month = getMonth(currentDate);
   const monthLabel = format(currentDate, 'MMMM', { locale: es });
-  let resumen = { normales: 0, extras: 0, nocturnas: 0, festivas: 0, adeber: 0 };
+  let resumen = { normales: 0, extras: 0, nocturnas: 0, festivas: 0, adeber: 0, pagadas: 0 };
 
   Object.entries(scheduleData).forEach(([dateKey, entry]) => {
     const d = parseISO(dateKey);
@@ -92,11 +92,15 @@ export function HoursSummary({ currentDate, scheduleData, onDownload }) {
           extrasDia = 0;
         }
       }
+      const pagadasDia = entry.pagada ? parseFloat(entry.horasPagadas || entry.horas_pagadas || 0) : 0;
+      const pagadasAplicadas = pagadasDia > 0 ? Math.min(extrasDia, pagadasDia) : 0;
+      extrasDia = pagadasDia > 0 ? Math.max(extrasDia - pagadasDia, 0) : extrasDia;
       resumen.normales += tipo.normales;
       resumen.extras += extrasDia;
       resumen.nocturnas += tipo.nocturnas;
       resumen.festivas += tipo.festivas;
       resumen.adeber += adeberDia;
+      resumen.pagadas += pagadasAplicadas;
     }
   });
 
@@ -147,6 +151,13 @@ export function HoursSummary({ currentDate, scheduleData, onDownload }) {
           <span className="text-purple-600 font-medium">Horas Extra laborable</span>
           <span className="text-md font-semibold text-purple-500">
             {formatHoursToHM(resumen.extras)}
+          </span>
+        </div>
+
+        <div className="flex justify-between items-center border-b pb-2">
+          <span className="text-emerald-600 font-medium">Horas pagadas</span>
+          <span className="text-md font-semibold text-emerald-500">
+            {formatHoursToHM(resumen.pagadas)}
           </span>
         </div>
 

--- a/gestor-frontend/src/components/HorasResumenAnual.jsx
+++ b/gestor-frontend/src/components/HorasResumenAnual.jsx
@@ -64,7 +64,7 @@ function calcularTipoHoras(intervals, dateKey, isFestivo, isVacaciones, isBaja) 
 export function YearHoursSummary({ currentDate, scheduleData, onDownload }) {
   const year = getYear(currentDate);
   const yearLabel = format(currentDate, 'yyyy');
-  let resumen = { normales: 0, extras: 0, nocturnas: 0, festivas: 0, adeber: 0 };
+  let resumen = { normales: 0, extras: 0, nocturnas: 0, festivas: 0, adeber: 0, pagadas: 0 };
 
   Object.entries(scheduleData).forEach(([dateKey, entry]) => {
     const d = parseISO(dateKey);
@@ -87,11 +87,15 @@ export function YearHoursSummary({ currentDate, scheduleData, onDownload }) {
           extrasDia = 0;
         }
       }
+      const pagadasDia = entry.pagada ? parseFloat(entry.horasPagadas || entry.horas_pagadas || 0) : 0;
+      const pagadasAplicadas = pagadasDia > 0 ? Math.min(extrasDia, pagadasDia) : 0;
+      extrasDia = pagadasDia > 0 ? Math.max(extrasDia - pagadasDia, 0) : extrasDia;
       resumen.normales += tipo.normales;
       resumen.extras += extrasDia;
       resumen.nocturnas += tipo.nocturnas;
       resumen.festivas += tipo.festivas;
       resumen.adeber += adeberDia;
+      resumen.pagadas += pagadasAplicadas;
     }
   });
 
@@ -145,6 +149,13 @@ export function YearHoursSummary({ currentDate, scheduleData, onDownload }) {
              {formatHoursToHM(resumen.extras)}
            </span>
          </div>
+
+          <div className="flex justify-between items-center border-b pb-2">
+            <span className="text-emerald-600 font-medium">Horas pagadas</span>
+            <span className="text-md font-semibold text-emerald-500">
+              {formatHoursToHM(resumen.pagadas)}
+            </span>
+          </div>
 
           <div className="flex justify-between items-center border-b pb-2">
             <span className="text-rose-600 font-medium">Horas a deber</span>

--- a/gestor-frontend/src/components/Organizacion.jsx
+++ b/gestor-frontend/src/components/Organizacion.jsx
@@ -295,6 +295,10 @@ export default function Organizacion() {
                     <span>Horas extras acumuladas</span>
                     <span className="font-bold">{stats.horasExtrasAcumuladas?.toFixed(1)}</span>
                   </li>
+                  <li className="flex justify-between">
+                    <span>Horas extras pagadas</span>
+                    <span className="font-bold">{stats.horasExtrasPagadas?.toFixed(1)}</span>
+                  </li>
                 </ul>
               </div>
             </div>


### PR DESCRIPTION
## Summary
- persist the new `pagada` and `horas_pagadas` fields for horarios and adjust aggregate stats to subtract paid overtime
- extend the schedule manager and modal so days can be marked as paid, display the state in the calendar, and send the paid hours to the API
- surface paid hour totals in the monthly/yearly summaries, Excel export, and organization dashboard widgets

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e4cda4b814832ba2685cd13ae74c04