### PR TITLE
Ajusta el cálculo de horas pagadas en los resúmenes

### DIFF
--- a/gestor-frontend/src/components/HorasResumen.jsx
+++ b/gestor-frontend/src/components/HorasResumen.jsx
@@ -81,6 +81,7 @@ export function HoursSummary({ currentDate, scheduleData, onDownload }) {
         entry.isVacation,
         entry.isBaja
       );
+      let normalesDia = tipo.normales;
       let extrasDia = tipo.extras;
       const neg = entry.horaNegativa || 0;
       let adeberDia = 0;
@@ -93,9 +94,24 @@ export function HoursSummary({ currentDate, scheduleData, onDownload }) {
         }
       }
       const pagadasDia = entry.pagada ? parseFloat(entry.horasPagadas || entry.horas_pagadas || 0) : 0;
-      const pagadasAplicadas = pagadasDia > 0 ? Math.min(extrasDia, pagadasDia) : 0;
-      extrasDia = pagadasDia > 0 ? Math.max(extrasDia - pagadasDia, 0) : extrasDia;
-      resumen.normales += tipo.normales;
+      let pagadasAplicadas = 0;
+      if (pagadasDia > 0) {
+        let restante = pagadasDia;
+
+        const pagadasNormales = Math.min(normalesDia, restante);
+        normalesDia -= pagadasNormales;
+        pagadasAplicadas += pagadasNormales;
+        restante -= pagadasNormales;
+
+        if (restante > 0) {
+          const pagadasExtras = Math.min(extrasDia, restante);
+          extrasDia -= pagadasExtras;
+          pagadasAplicadas += pagadasExtras;
+          restante -= pagadasExtras;
+        }
+      }
+
+      resumen.normales += normalesDia;
       resumen.extras += extrasDia;
       resumen.nocturnas += tipo.nocturnas;
       resumen.festivas += tipo.festivas;

--- a/gestor-frontend/src/components/HorasResumenAnual.jsx
+++ b/gestor-frontend/src/components/HorasResumenAnual.jsx
@@ -76,6 +76,7 @@ export function YearHoursSummary({ currentDate, scheduleData, onDownload }) {
         entry.isVacation,
         entry.isBaja
       );
+      let normalesDia = tipo.normales;
       let extrasDia = tipo.extras;
       const neg = entry.horaNegativa || 0;
       let adeberDia = 0;
@@ -88,9 +89,24 @@ export function YearHoursSummary({ currentDate, scheduleData, onDownload }) {
         }
       }
       const pagadasDia = entry.pagada ? parseFloat(entry.horasPagadas || entry.horas_pagadas || 0) : 0;
-      const pagadasAplicadas = pagadasDia > 0 ? Math.min(extrasDia, pagadasDia) : 0;
-      extrasDia = pagadasDia > 0 ? Math.max(extrasDia - pagadasDia, 0) : extrasDia;
-      resumen.normales += tipo.normales;
+      let pagadasAplicadas = 0;
+      if (pagadasDia > 0) {
+        let restante = pagadasDia;
+
+        const pagadasNormales = Math.min(normalesDia, restante);
+        normalesDia -= pagadasNormales;
+        pagadasAplicadas += pagadasNormales;
+        restante -= pagadasNormales;
+
+        if (restante > 0) {
+          const pagadasExtras = Math.min(extrasDia, restante);
+          extrasDia -= pagadasExtras;
+          pagadasAplicadas += pagadasExtras;
+          restante -= pagadasExtras;
+        }
+      }
+
+      resumen.normales += normalesDia;
       resumen.extras += extrasDia;
       resumen.nocturnas += tipo.nocturnas;
       resumen.festivas += tipo.festivas;

--- a/gestor-frontend/src/utils/exportExcel.js
+++ b/gestor-frontend/src/utils/exportExcel.js
@@ -197,6 +197,7 @@ export async function addScheduleWorksheet(
       entry.baja
     );
 
+    let normalesFinal = normales;
     let extrasFinal = extras;
     let adeber = 0;
     const neg = entry.horanegativa || 0;
@@ -210,10 +211,24 @@ export async function addScheduleWorksheet(
     }
 
     const horasPagadas = entry.pagada ? parseFloat(entry.horas_pagadas || 0) : 0;
-    const pagadasAplicadas = horasPagadas > 0 ? Math.min(extrasFinal, horasPagadas) : 0;
-    extrasFinal = horasPagadas > 0 ? Math.max(extrasFinal - horasPagadas, 0) : extrasFinal;
+    let pagadasAplicadas = 0;
+    if (horasPagadas > 0) {
+      let restante = horasPagadas;
 
-    totalNormales += normales;
+      const pagadasNormales = Math.min(normalesFinal, restante);
+      normalesFinal -= pagadasNormales;
+      pagadasAplicadas += pagadasNormales;
+      restante -= pagadasNormales;
+
+      if (restante > 0) {
+        const pagadasExtras = Math.min(extrasFinal, restante);
+        extrasFinal -= pagadasExtras;
+        pagadasAplicadas += pagadasExtras;
+        restante -= pagadasExtras;
+      }
+    }
+
+    totalNormales += normalesFinal;
     totalExtras += extrasFinal;
     totalAdeber += adeber;
     totalNocturnas += nocturnas;
@@ -227,7 +242,7 @@ export async function addScheduleWorksheet(
       'Salida 1': salida1,
       'Entrada 2': entrada2,
       'Salida 2': salida2,
-      'Normales': toHM(normales),
+      'Normales': toHM(normalesFinal),
       'Extras': toHM(extrasFinal),
       'A Deber': entry.dianegativo ? 'Día negativo' : adeber > 0 ? `-${toHM(adeber)}` : '',
       'Nocturnas': toHM(nocturnas),


### PR DESCRIPTION
## Summary
- Ajusta los resúmenes mensual y anual para descontar primero las horas pagadas de las horas normales y, si procede, de las extras
- Alinea la exportación a Excel con la nueva lógica para que los totales de horas pagadas coincidan

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e4e4f4f2d8832b81ef27cee24a05cc