### PR TITLE
Fix paid holiday hours deduction

### DIFF
--- a/gestor-frontend/src/components/HorasResumen.jsx
+++ b/gestor-frontend/src/components/HorasResumen.jsx
@@ -57,6 +57,8 @@ export function HoursSummary({ currentDate, scheduleData, onDownload }) {
             applied = Math.min(nocturnasDia, safeAmount);
             nocturnasDia -= applied;
             break;
+          case 'festivo':
+          case 'festiva':
           case 'festivas':
             applied = Math.min(festivasDia, safeAmount);
             festivasDia -= applied;
@@ -82,6 +84,20 @@ export function HoursSummary({ currentDate, scheduleData, onDownload }) {
             extrasDia -= pagadasExtras;
             pagadasAplicadas += pagadasExtras;
             restante -= pagadasExtras;
+          }
+
+          if (restante > 0) {
+            const pagadasNocturnas = Math.min(nocturnasDia, restante);
+            nocturnasDia -= pagadasNocturnas;
+            pagadasAplicadas += pagadasNocturnas;
+            restante -= pagadasNocturnas;
+          }
+
+          if (restante > 0) {
+            const pagadasFestivas = Math.min(festivasDia, restante);
+            festivasDia -= pagadasFestivas;
+            pagadasAplicadas += pagadasFestivas;
+            restante -= pagadasFestivas;
           }
         }
       }

--- a/gestor-frontend/src/components/HorasResumenAnual.jsx
+++ b/gestor-frontend/src/components/HorasResumenAnual.jsx
@@ -55,6 +55,8 @@ export function YearHoursSummary({ currentDate, scheduleData, onDownload }) {
             applied = Math.min(nocturnasDia, safeAmount);
             nocturnasDia -= applied;
             break;
+          case 'festivo':
+          case 'festiva':
           case 'festivas':
             applied = Math.min(festivasDia, safeAmount);
             festivasDia -= applied;
@@ -81,6 +83,20 @@ export function YearHoursSummary({ currentDate, scheduleData, onDownload }) {
             extrasDia -= pagadasExtras;
             pagadasAplicadas += pagadasExtras;
             restante -= pagadasExtras;
+          }
+
+          if (restante > 0) {
+            const pagadasNocturnas = Math.min(nocturnasDia, restante);
+            nocturnasDia -= pagadasNocturnas;
+            pagadasAplicadas += pagadasNocturnas;
+            restante -= pagadasNocturnas;
+          }
+
+          if (restante > 0) {
+            const pagadasFestivas = Math.min(festivasDia, restante);
+            festivasDia -= pagadasFestivas;
+            pagadasAplicadas += pagadasFestivas;
+            restante -= pagadasFestivas;
           }
         }
       }

--- a/gestor-frontend/src/utils/exportExcel.js
+++ b/gestor-frontend/src/utils/exportExcel.js
@@ -208,6 +208,8 @@ export async function addScheduleWorksheet(
           applied = Math.min(nocturnasFinal, safeAmount);
           nocturnasFinal -= applied;
           break;
+        case 'festivo':
+        case 'festiva':
         case 'festivas':
           applied = Math.min(festivasFinal, safeAmount);
           festivasFinal -= applied;
@@ -234,6 +236,20 @@ export async function addScheduleWorksheet(
           extrasFinal -= pagadasExtras;
           pagadasAplicadas += pagadasExtras;
           restante -= pagadasExtras;
+        }
+
+        if (restante > 0) {
+          const pagadasNocturnas = Math.min(nocturnasFinal, restante);
+          nocturnasFinal -= pagadasNocturnas;
+          pagadasAplicadas += pagadasNocturnas;
+          restante -= pagadasNocturnas;
+        }
+
+        if (restante > 0) {
+          const pagadasFestivas = Math.min(festivasFinal, restante);
+          festivasFinal -= pagadasFestivas;
+          pagadasAplicadas += pagadasFestivas;
+          restante -= pagadasFestivas;
         }
       }
     }


### PR DESCRIPTION
## Summary
- ensure monthly and annual hour summaries deduct paid holiday hours even when the stored payment type label does not match the expected key
- extend the fallback redistribution of paid hours so any remaining balance is applied across nocturnal and holiday buckets
- mirror the updated paid-hour handling when exporting schedules to Excel to keep reports consistent

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e649ad3100832b89c25d2f8f7a5b6d