### PR TITLE
Rename header label to "Brands" and improve logo contrast

### DIFF
--- a/gestor-frontend/src/components/EmpresaSelector.jsx
+++ b/gestor-frontend/src/components/EmpresaSelector.jsx
@@ -183,7 +183,7 @@ export default function EmpresaSelector() {
               </div>
               <div>
                 <p className="text-xs font-semibold uppercase tracking-[0.2em] text-emerald-200/80">
-                  ERP Company Hub
+                  Brands
                 </p>
                 <h1 className="text-2xl font-semibold text-white">
                   Selecciona empresa y personaliza tu experiencia

--- a/gestor-frontend/src/components/Header.jsx
+++ b/gestor-frontend/src/components/Header.jsx
@@ -133,7 +133,9 @@ export default function Header() {
               >
                 <Building2 className="h-5 w-5" />
               </div>
-              <img className="h-7 w-auto" alt="Logo" src={logoSrc} />
+              <div className="brand-logo">
+                <img alt="Logo" src={logoSrc} />
+              </div>
             </div>
             <nav className="hidden md:block ml-10">
               <div className="flex items-baseline space-x-4">

--- a/gestor-frontend/src/index.css
+++ b/gestor-frontend/src/index.css
@@ -13,6 +13,22 @@
   .theme-muted {
     color: var(--theme-text-muted);
   }
+
+  .brand-logo {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0.25rem 0.5rem;
+    border-radius: 0.75rem;
+    background: var(--theme-logo-bg);
+    border: 1px solid var(--theme-logo-border);
+    box-shadow: var(--theme-logo-shadow);
+  }
+
+  .brand-logo img {
+    height: 1.75rem;
+    width: auto;
+  }
 }
 
 :root {
@@ -30,6 +46,9 @@
   --theme-chip-border: rgba(148, 163, 184, 0.2);
   --theme-ring: rgba(99, 102, 241, 0.45);
   --theme-shadow: 0 30px 80px rgba(2, 6, 23, 0.55);
+  --theme-logo-bg: rgba(255, 255, 255, 0.9);
+  --theme-logo-border: rgba(15, 23, 42, 0.15);
+  --theme-logo-shadow: 0 6px 18px rgba(15, 23, 42, 0.18);
 }
 
 [data-theme='sapphire'] {
@@ -66,4 +85,12 @@
   --theme-accent-strong: #f97316;
   --theme-accent-soft: rgba(251, 146, 60, 0.18);
   --theme-ring: rgba(251, 146, 60, 0.5);
+}
+
+@media (prefers-color-scheme: light) {
+  :root {
+    --theme-logo-bg: rgba(15, 23, 42, 0.92);
+    --theme-logo-border: rgba(15, 23, 42, 0.3);
+    --theme-logo-shadow: 0 8px 18px rgba(2, 6, 23, 0.25);
+  }
 }


### PR DESCRIPTION
### Motivation
- The company selector heading needed to be renamed to a more generic "Brands" label.
- Some logos were hard to see against dark or light backgrounds, so a small visual wrapper and theme-aware variables were required to improve contrast.
- Provide an easy place to tweak logo background/border/shadow colors for different themes and color-schemes.

### Description
- Changed the header/hero label in `gestor-frontend/src/components/EmpresaSelector.jsx` from "ERP Company Hub" to "Brands".
- Added a reusable `.brand-logo` component style and theme variables `--theme-logo-bg`, `--theme-logo-border`, and `--theme-logo-shadow` in `gestor-frontend/src/index.css`, including a `prefers-color-scheme: light` override.
- Wrapped the header logo image with the new `.brand-logo` container in `gestor-frontend/src/components/Header.jsx` and constrained the logo size for consistent rendering.

### Testing
- Launched the dev server with `npm run dev -- --host 0.0.0.0 --port 4173` and the server reported ready (Vite started successfully).
- Ran a Playwright script that opened `http://127.0.0.1:4173/dashboard` (with test localStorage values) and captured a screenshot successfully at `artifacts/brands-header.png`.
- No unit tests were present or executed in this change set.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_696f3f2b01fc83229e0a9df501e3918e)