### PR TITLE
Mostrar fecha de baja al editar trabajador

### DIFF
--- a/gestor-frontend/src/components/forms/EditWorkerModal.jsx
+++ b/gestor-frontend/src/components/forms/EditWorkerModal.jsx
@@ -23,6 +23,7 @@ export default function EditWorkerModal({ open, onClose, onWorkerUpdated, initia
   const [form, setForm] = useState({});
   const [formErrors, setFormErrors] = useState({});
   const { empresas } = useEmpresa();
+  const shouldShowFechaBaja = form.tipo_trabajador !== 'Fijo' || Boolean(form.fecha_baja);
 
   const empresaOptions = useMemo(() => {
     const names = empresas.map((empresa) => empresa.nombre).filter(Boolean);
@@ -229,7 +230,7 @@ export default function EditWorkerModal({ open, onClose, onWorkerUpdated, initia
                 {renderInput('Grupo', 'grupo', 'Ej: G1')}
                 {renderInput('Categoría', 'categoria', 'Ej: Oficial 1ª')}
                 {renderInput('Fecha de Alta', 'fecha_alta', '', 'date')}
-                {form.tipo_trabajador !== 'Fijo' && renderInput('Fecha de Baja', 'fecha_baja', '', 'date')}
+                {shouldShowFechaBaja && renderInput('Fecha de Baja', 'fecha_baja', '', 'date')}
                 {renderInput('Horas Contratadas', 'horas_contratadas', 'Ej: 40', 'number')}
                 <div className="sm:col-span-2 grid grid-cols-1 gap-4 sm:grid-cols-2">
                   {renderInput('Salario Neto/Mensual (€)', 'salario_neto', 'Ej: 1.600,50')}


### PR DESCRIPTION
### Motivation
- Cuando se edita la ficha de un trabajador con `fecha_baja` ya registrada no se mostraba el campo de "Fecha de Baja" si el `tipo_trabajador` era `Fijo`, impidiendo ver o corregir esa fecha existente.

### Description
- Añadido el cálculo `shouldShowFechaBaja = form.tipo_trabajador !== 'Fijo' || Boolean(form.fecha_baja)` en `gestor-frontend/src/components/forms/EditWorkerModal.jsx` para decidir si se muestra el campo de fecha de baja. 
- Reemplazada la condición de renderizado antigua por `shouldShowFechaBaja` para que el campo `Fecha de Baja` se muestre también cuando ya exista una `fecha_baja` aunque el contrato sea `Fijo`.

### Testing
- Instalación de dependencias con `npm install` en `gestor-frontend` completada correctamente. 
- Levantado el servidor de desarrollo con `npm run dev` y ejecutado un script de Playwright que navegó a `/trabajador` y generó una captura (`artifacts/trabajadores-page.png`), confirmando la interfaz cargada sin errores.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6979fda011d48322abe824e84845f1c7)