### PR TITLE
Fix baja date handling for workers

### DIFF
--- a/gestor-frontend/src/components/Trabajador.jsx
+++ b/gestor-frontend/src/components/Trabajador.jsx
@@ -25,7 +25,7 @@ import { motion, AnimatePresence } from 'framer-motion';
 import AddWorkerModal from '@/components/forms/AddWorkerModal';
 import EditWorkerModal from '@/components/forms/EditWorkerModal';
 import { exportWorkerToExcel, exportWorkersSelectionToExcel } from '@/utils/exportWorkerExcel';
-import { formatCurrency } from '@/utils/utils';
+import { formatCurrency, getLocalDateString } from '@/utils/utils';
 import { apiUrl } from '@/utils/api';
 import apiClient from '@/utils/apiClient';
 import { useEmpresa } from '@/context/EmpresaContext';
@@ -222,7 +222,7 @@ export default function Trabajador() {
     if (!window.confirm('¿Deseas dar de baja a este trabajador?')) return;
 
     try {
-      const fechaHoy = new Date().toISOString().split('T')[0];
+      const fechaHoy = getLocalDateString();
       await apiClient.put(apiUrl(`trabajadores/${id}`), {
         fecha_baja: fechaHoy
       });

--- a/gestor-frontend/src/utils/utils.js
+++ b/gestor-frontend/src/utils/utils.js
@@ -163,6 +163,12 @@ export function parseCurrency(value) {
   return parseFloat(str.replace(/\./g, ''));
 }
 
+export function getLocalDateString(date = new Date()) {
+  const offsetMs = date.getTimezoneOffset() * 60 * 1000;
+  const localTime = new Date(date.getTime() - offsetMs);
+  return localTime.toISOString().split('T')[0];
+}
+
 export const PAYMENT_TYPE_LABELS = {
   normales: 'Normales',
   extras: 'Extra laborable',


### PR DESCRIPTION
### Motivation
- Ensure the date sent to the backend when a worker is given "baja" uses the local YYYY-MM-DD value (avoid timezone-shifted ISO date).

### Description
- Add `getLocalDateString` helper in `src/utils/utils.js` to produce a local `YYYY-MM-DD` string and import it in `src/components/Trabajador.jsx`; replace the previous `new Date().toISOString().split('T')[0]` usage with `getLocalDateString()` when setting `fecha_baja`.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_697b4f3d63a08322b805425959dc0756)