### PR TITLE
Mostrar `fecha_baja` siempre en formularios de trabajador

### DIFF
--- a/gestor-frontend/src/components/forms/AddWorkerModal.jsx
+++ b/gestor-frontend/src/components/forms/AddWorkerModal.jsx
@@ -240,7 +240,7 @@ export default function AddWorkerModal({ open, onClose, onWorkerAdded }) {
                 {renderInput('Grupo', 'grupo', 'Ej: G1')}
                 {renderInput('Categoría', 'categoria', 'Ej: Oficial 1ª')}
                 {renderInput('Fecha de Alta', 'fecha_alta', '', 'date')}
-                {form.tipo_trabajador !== 'Fijo' && renderInput('Fecha de Baja', 'fecha_baja', '', 'date')}
+                {renderInput('Fecha de Baja', 'fecha_baja', '', 'date')}
                 {renderInput('Horas Contratadas', 'horas_contratadas', 'Ej: 40', 'number')}
                 <div className="sm:col-span-2 grid grid-cols-1 gap-4 sm:grid-cols-2">
                   {renderInput('Salario Neto/Mensual (€)', 'salario_neto', 'Ej: 1.600,50')}

--- a/gestor-frontend/src/components/forms/EditWorkerModal.jsx
+++ b/gestor-frontend/src/components/forms/EditWorkerModal.jsx
@@ -229,7 +229,7 @@ export default function EditWorkerModal({ open, onClose, onWorkerUpdated, initia
                 {renderInput('Grupo', 'grupo', 'Ej: G1')}
                 {renderInput('Categoría', 'categoria', 'Ej: Oficial 1ª')}
                 {renderInput('Fecha de Alta', 'fecha_alta', '', 'date')}
-                {form.tipo_trabajador !== 'Fijo' && renderInput('Fecha de Baja', 'fecha_baja', '', 'date')}
+                {renderInput('Fecha de Baja', 'fecha_baja', '', 'date')}
                 {renderInput('Horas Contratadas', 'horas_contratadas', 'Ej: 40', 'number')}
                 <div className="sm:col-span-2 grid grid-cols-1 gap-4 sm:grid-cols-2">
                   {renderInput('Salario Neto/Mensual (€)', 'salario_neto', 'Ej: 1.600,50')}


### PR DESCRIPTION
### Motivation
- Asegurar que el campo `fecha_baja` siempre sea visible al añadir o editar un trabajador independientemente del tipo de contrato.

### Description
- Se eliminó la condición que ocultaba el input de `Fecha de Baja` para contrato `Fijo` en `AddWorkerModal.jsx` y `EditWorkerModal.jsx`, mostrando ahora `renderInput('Fecha de Baja', 'fecha_baja', '', 'date')` de forma incondicional.

### Testing
- Intenté instalar dependencias y levantar el frontend con `npm install` en `gestor-frontend`, pero falló con `403 Forbidden` desde el registro npm, por lo que no se pudieron ejecutar pruebas automáticas ni la verificación en la aplicación.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_697b79b4c3ec8322837e4672681398ed)