### PR TITLE
Add confirmation modal for alta/baja actions

### DIFF
--- a/gestor-frontend/src/components/ConfirmActionModal.jsx
+++ b/gestor-frontend/src/components/ConfirmActionModal.jsx
@@ -1,0 +1,64 @@
+import { Dialog } from '@headlessui/react';
+
+const actionCopy = {
+  alta: {
+    title: 'Dar de alta trabajador',
+    description: 'Se reactivará el trabajador y quedará disponible en la lista activa.',
+    confirmLabel: 'Dar de alta',
+    panelAccent: 'border-emerald-500/60',
+    buttonStyles: 'bg-emerald-600 hover:bg-emerald-700 focus-visible:ring-emerald-500'
+  },
+  baja: {
+    title: 'Dar de baja trabajador',
+    description: 'El trabajador quedará marcado como inactivo a partir de hoy.',
+    confirmLabel: 'Dar de baja',
+    panelAccent: 'border-amber-500/70',
+    buttonStyles: 'bg-amber-500 hover:bg-amber-600 focus-visible:ring-amber-400'
+  }
+};
+
+export default function ConfirmActionModal({
+  open,
+  onClose,
+  onConfirm,
+  actionType = 'baja',
+  workerName
+}) {
+  const copy = actionCopy[actionType] ?? actionCopy.baja;
+  return (
+    <Dialog open={open} onClose={onClose} className="fixed inset-0 z-50 flex items-center justify-center">
+      <div className="fixed inset-0 bg-slate-900/60 backdrop-blur-sm" aria-hidden="true" />
+      <Dialog.Panel
+        className={`relative z-10 w-full max-w-lg rounded-2xl border ${copy.panelAccent} bg-white p-6 shadow-xl`}
+      >
+        <Dialog.Title className="text-lg font-semibold text-slate-900">
+          {copy.title}
+        </Dialog.Title>
+        <div className="mt-3 space-y-2 text-sm text-slate-600">
+          <p>{copy.description}</p>
+          {workerName && (
+            <p className="font-medium text-slate-800">
+              Trabajador: <span className="font-semibold">{workerName}</span>
+            </p>
+          )}
+        </div>
+        <div className="mt-6 flex flex-wrap justify-end gap-3">
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded-lg border border-slate-200 px-4 py-2 text-sm font-medium text-slate-600 hover:bg-slate-50"
+          >
+            Cancelar
+          </button>
+          <button
+            type="button"
+            onClick={onConfirm}
+            className={`rounded-lg px-4 py-2 text-sm font-semibold text-white shadow-sm focus-visible:outline-none focus-visible:ring-2 ${copy.buttonStyles}`}
+          >
+            {copy.confirmLabel}
+          </button>
+        </div>
+      </Dialog.Panel>
+    </Dialog>
+  );
+}

--- a/gestor-frontend/src/components/Trabajador.jsx
+++ b/gestor-frontend/src/components/Trabajador.jsx
@@ -24,6 +24,7 @@ import {
 import { motion, AnimatePresence } from 'framer-motion';
 import AddWorkerModal from '@/components/forms/AddWorkerModal';
 import EditWorkerModal from '@/components/forms/EditWorkerModal';
+import ConfirmActionModal from '@/components/ConfirmActionModal';
 import { exportWorkerToExcel, exportWorkersSelectionToExcel } from '@/utils/exportWorkerExcel';
 import { formatCurrency, getLocalDateString } from '@/utils/utils';
 import { apiUrl } from '@/utils/api';
@@ -102,6 +103,11 @@ export default function Trabajador() {
   const [filterBy, setFilterBy] = useState('nombre');
   const [showAddModal, setShowAddModal] = useState(false);
   const [showEditModal, setShowEditModal] = useState(false);
+  const [confirmAction, setConfirmAction] = useState({
+    open: false,
+    type: 'baja',
+    trabajador: null
+  });
   const [trabajadorSeleccionado, setTrabajadorSeleccionado] = useState(null);
   const [currentPage, setCurrentPage] = useState(1);
   const [selectedFields, setSelectedFields] = useState(['nombre', 'dni', 'epis']);
@@ -203,9 +209,7 @@ export default function Trabajador() {
     setShowEditModal(false);
   }, [empresaId]);
 
-  const handleAlta = async (id) => {
-    if (!window.confirm('¿Deseas volver a dar de alta a este trabajador?')) return;
-
+  const executeAlta = async (id) => {
     try {
       await apiClient.put(apiUrl(`trabajadores/${id}`), {
         fecha_baja: null
@@ -218,9 +222,7 @@ export default function Trabajador() {
     }
   };
 
-  const handleBaja = async (id) => {
-    if (!window.confirm('¿Deseas dar de baja a este trabajador?')) return;
-
+  const executeBaja = async (id) => {
     try {
       const fechaHoy = getLocalDateString();
       await apiClient.put(apiUrl(`trabajadores/${id}`), {
@@ -232,6 +234,36 @@ export default function Trabajador() {
       console.error('Error al dar de baja:', err);
       alert('No se pudo dar de baja al trabajador.');
     }
+  };
+
+  const openConfirmAction = (type, trabajador) => {
+    setConfirmAction({
+      open: true,
+      type,
+      trabajador
+    });
+  };
+
+  const closeConfirmAction = () => {
+    setConfirmAction((prev) => ({
+      ...prev,
+      open: false
+    }));
+  };
+
+  const handleConfirmAction = async () => {
+    if (!confirmAction.trabajador) {
+      closeConfirmAction();
+      return;
+    }
+
+    if (confirmAction.type === 'alta') {
+      await executeAlta(confirmAction.trabajador.id);
+    } else {
+      await executeBaja(confirmAction.trabajador.id);
+    }
+
+    closeConfirmAction();
   };
 
   const handleEdit = (trabajador) => {
@@ -565,14 +597,14 @@ export default function Trabajador() {
                     {isActivo(t) ? (
                       t.fecha_baja ? (
                         <button
-                          onClick={() => handleAlta(t.id)}
+                          onClick={() => openConfirmAction('alta', t)}
                           className="flex items-center gap-1 px-3 py-2 border border-green-600 text-green-700 text-sm rounded-lg hover:bg-green-50"
                         >
                           <Calendar className="w-4 h-4" /> Cancelar baja
                         </button>
                       ) : (
                         <button
-                          onClick={() => handleBaja(t.id)}
+                          onClick={() => openConfirmAction('baja', t)}
                           className="flex items-center gap-1 px-3 py-2 border border-amber-500 text-amber-600 text-sm rounded-lg hover:bg-amber-50"
                         >
                           <Calendar className="w-4 h-4" /> Dar de baja
@@ -580,7 +612,7 @@ export default function Trabajador() {
                       )
                     ) : (
                       <button
-                        onClick={() => handleAlta(t.id)}
+                        onClick={() => openConfirmAction('alta', t)}
                         className="flex items-center gap-1 px-3 py-2 border border-green-600 text-green-700 text-sm rounded-lg hover:bg-green-50"
                       >
                         <Calendar className="w-4 h-4" /> Dar de alta
@@ -609,6 +641,13 @@ export default function Trabajador() {
           onClose={() => setShowEditModal(false)}
           onWorkerUpdated={fetchWorkers}
           initialData={trabajadorSeleccionado}
+        />
+        <ConfirmActionModal
+          open={confirmAction.open}
+          onClose={closeConfirmAction}
+          onConfirm={handleConfirmAction}
+          actionType={confirmAction.type}
+          workerName={confirmAction.trabajador?.nombre}
         />
 
         {totalPages > 1 && (


### PR DESCRIPTION
### Motivation

- Reemplazar los diálogos nativos `window.confirm` usados para "dar de alta" / "dar de baja" por una UI coherente y más atractiva.
- Evitar confirmaciones abruptas y mostrar información contextual (nombre del trabajador y copy específico) antes de ejecutar la acción.

### Description

- Añade el componente `ConfirmActionModal` en `gestor-frontend/src/components/ConfirmActionModal.jsx` con copy y estilos para las acciones `alta` y `baja`.
- Sustituye los `window.confirm` en `Trabajador.jsx` por un flujo de estado que abre el modal y gestiona `open`, `type` y `trabajador` en `confirmAction`.
- Extrae la lógica de efecto en `Trabajador.jsx` a las funciones `executeAlta` y `executeBaja` y llama a la correspondiente desde el handler del modal (`handleConfirmAction`).
- Integra el modal en el render de `Trabajador` pasando `actionType` y `workerName` para mostrar información contextual.

### Testing

- Levanté el servidor de desarrollo con `npm run dev` y el servidor Vite quedó listo (accesible localmente), por lo que la app cargó correctamente.
- Ejecuté un script de Playwright que navegó a la app y tomó una captura de pantalla `artifacts/trabajador-modal.png`, confirmando que el modal se renderiza en la UI; la captura se generó con éxito.
- No se añadieron tests unitarios automáticos en este cambio.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_697b7bf20ff0832290f71366f13e2d5c)